### PR TITLE
Fixes <date-field>-between functions for moments:

### DIFF
--- a/gregor-lib/gregor/private/generics.rkt
+++ b/gregor-lib/gregor/private/generics.rkt
@@ -29,17 +29,17 @@
   (->iso-week   date-provider)
   (->iso-wyear  date-provider)
   (->iso-wday   date-provider)
-  
+
   (+years       date-provider n #:resolve-offset [resolve-offset])
   (+months      date-provider n #:resolve-offset [resolve-offset])
   (+weeks       date-provider n #:resolve-offset [resolve-offset])
   (+days        date-provider n #:resolve-offset [resolve-offset])
-  
+
   (-years       date-provider n #:resolve-offset [resolve-offset])
   (-months      date-provider n #:resolve-offset [resolve-offset])
   (-weeks       date-provider n #:resolve-offset [resolve-offset])
   (-days        date-provider n #:resolve-offset [resolve-offset])
-  
+
   (sunday?      date-provider)
   (monday?      date-provider)
   (tuesday?     date-provider)
@@ -47,14 +47,14 @@
   (thursday?    date-provider)
   (friday?      date-provider)
   (saturday?    date-provider)
-  
+
   (with-ymd     date-provider ymd #:resolve-offset [resolve-offset])
   (with-jdn     date-provider jdn #:resolve-offset [resolve-offset])
 
   (at-time      date-provider t #:resolve-offset [resolve-offset])
   (at-midnight  date-provider #:resolve-offset [resolve-offset])
   (at-noon      date-provider #:resolve-offset [resolve-offset])
-  
+
   #:defaults
   ([date?
     (define ->date      (λ (x) x))
@@ -64,7 +64,7 @@
                           (jdn->date jdn)))
     (define at-time     (λ (d t #:resolve-offset [_ resolve-offset/raise])
                           (date+time->datetime d (->time t))))]
-   
+
    [datetime?
     (define ->date      datetime->date)
     (define with-ymd    (λ (dt ymd #:resolve-offset [_ resolve-offset/raise])
@@ -73,12 +73,12 @@
                           (date+time->datetime (jdn->date jdn) (datetime->time dt))))
     (define at-time     (λ (dt t #:resolve-offset [_ resolve-offset/raise])
                           (date+time->datetime (datetime->date dt) (->time t))))]
-   
+
    [moment?
     (define/generic /ymd with-ymd)
     (define/generic /jdn with-jdn)
     (define/generic @time at-time)
-    
+
     (define ->date      (compose1 datetime->date moment->datetime/local))
     (define with-ymd    (λ (m ymd #:resolve-offset [r resolve-offset/raise])
                           (define dt (/ymd (moment->datetime/local m) ymd))
@@ -89,15 +89,15 @@
     (define at-time     (λ (m t #:resolve-offset [r resolve-offset/raise])
                           (define dt (@time (moment->datetime/local m) (->time t)))
                           (datetime+tz->moment dt (moment->timezone m) r)))])
-  
+
   #:fallbacks
   [(define/generic as-date ->date)
    (define ->ymd (compose1 date->ymd as-date))
    (define ->jdn (compose1 date->jdn as-date))
-   
+
    (define/generic from-ymd with-ymd)
    (define/generic from-jdn with-jdn)
-   
+
    (define ->year      (compose1 YMD-y ->ymd))
    (define ->quarter   (compose1 ymd->quarter ->ymd))
    (define ->month     (compose1 YMD-m ->ymd))
@@ -111,7 +111,7 @@
    (define (resolve/orig resolve orig)
      (λ (g/o dt tzid m)
        (resolve g/o dt tzid (or m (and (moment? orig) orig)))))
-   
+
    (define (d+ from as fn)
      (λ (d n #:resolve-offset [resolve resolve-offset/retain])
        (from d (fn (as d) n) #:resolve-offset (resolve/orig resolve d))))
@@ -119,23 +119,23 @@
    (define (d- from as fn)
      (λ (d n #:resolve-offset [resolve resolve-offset/retain])
        (from d (fn (as d) (- n)) #:resolve-offset (resolve/orig resolve d))))
-   
+
    (define (ymd+ fn)   (d+ from-ymd ->ymd fn))
    (define (ymd- fn)   (d- from-ymd ->ymd fn))
    (define (jdn+ fn)   (d+ from-jdn ->jdn fn))
-   
+
    (define +years   (ymd+ ymd-add-years))
    (define +months  (ymd+ ymd-add-months))
    (define +days    (jdn+ +))
    (define +weeks   (jdn+ (λ (x y) (+ x (* y 7)))))
-   
+
    (define -years   (ymd- ymd-add-years))
    (define -months  (ymd- ymd-add-months))
    (define -days    (jdn+ -))
    (define -weeks   (jdn+ (λ (x y) (- x (* y 7)))))
-   
+
    (define (dow? n)    (λ (d) (= n (->wday d))))
-   
+
    (define sunday?     (dow? 0))
    (define monday?     (dow? 1))
    (define tuesday?    (dow? 2))
@@ -143,7 +143,7 @@
    (define thursday?   (dow? 4))
    (define friday?     (dow? 5))
    (define saturday?   (dow? 6))
-   
+
    (define/generic @time at-time)
    (define at-midnight (λ (d #:resolve-offset [_ resolve-offset/raise])
                          (@time d MIDNIGHT #:resolve-offset _)))
@@ -159,80 +159,80 @@
   (->milliseconds time-provider)
   (->microseconds time-provider)
   (->nanoseconds  time-provider)
-  
+
   (+hours         time-provider n)
   (+minutes       time-provider n)
   (+seconds       time-provider n)
   (+milliseconds  time-provider n)
   (+microseconds  time-provider n)
   (+nanoseconds   time-provider n)
-  
+
   (-hours         time-provider n)
   (-minutes       time-provider n)
   (-seconds       time-provider n)
   (-milliseconds  time-provider n)
   (-microseconds  time-provider n)
   (-nanoseconds   time-provider n)
-  
+
   (on-date        time-provider d #:resolve-offset [resolve-offset])
-  
+
   #:defaults
   ([time?
     (define ->time          (λ (x) x))
-    
+
     (define (+nanoseconds t n)
       (day-ns->time
        (mod (+ (time->ns t) n)
             NS/DAY)))
-    
+
     (define (on-date t d #:resolve-offset [_ resolve-offset/raise])
       (date+time->datetime (->date d) t))]
-   
+
    [datetime?
     (define ->time          datetime->time)
     (define +nanoseconds    datetime-add-nanoseconds)
     (define on-date         (λ (dt d #:resolve-offset [_ resolve-offset/raise])
                               (date+time->datetime (->date d) (->time dt))))]
-   
+
    [moment?
     (define/generic on-date/g on-date)
-    
+
     (define ->time          (compose1 datetime->time moment->datetime/local))
     (define +nanoseconds    moment-add-nanoseconds)
     (define on-date         (λ (m d #:resolve-offset [r resolve-offset/raise])
                               (define dt (on-date/g (moment->datetime/local m) d))
                               (datetime+tz->moment dt (moment->timezone m) r)))])
-  
+
   #:fallbacks
   [(define/generic as-time ->time)
-   
+
    (define ->hmsn          (compose1 time->hmsn as-time))
-   
+
    (define ->hours         (compose1 HMSN-h ->hmsn))
    (define ->minutes       (compose1 HMSN-m ->hmsn))
-    
+
    (define ->seconds       (λ (t [fractional? #f])
                              (match-define (HMSN _ _ s n) (->hmsn t))
 
                              (+ s (if fractional?
                                       (/ n NS/SECOND)
                                       0))))
-    
+
    (define ->nanoseconds   (compose1 HMSN-n ->hmsn))
    (define ->milliseconds  (λ (t) (exact-floor (/ (->nanoseconds t) 1000000))))
    (define ->microseconds  (λ (t) (exact-floor (/ (->nanoseconds t) 1000))))
-    
+
    (define/generic ns+ +nanoseconds)
 
    (define (-nanoseconds t n) (ns+ t (- n)))
-      
+
    (define (t+/- NS/UNIT i)
      (λ (t n)
        (ns+ t (* n NS/UNIT i))))
-   
+
    (define (t+ NS/UNIT) (t+/- NS/UNIT 1))
    (define (t- NS/UNIT) (t+/- NS/UNIT -1))
-   
+
    (define +hours          (t+ NS/HOUR))
    (define +minutes        (t+ NS/MINUTE))
    (define +seconds        (t+ NS/SECOND))
@@ -244,14 +244,15 @@
    (define -seconds        (t- NS/SECOND))
    (define -milliseconds   (t- NS/MILLI))
    (define -microseconds   (t- NS/MICRO))])
-  
+
 
 (define-generics datetime-provider
   (->datetime/local      datetime-provider)
   (->datetime/utc        datetime-provider)
+  (->datetime/similar    datetime-provider other)
   (->posix               datetime-provider)
   (->jd                  datetime-provider)
-  
+
   (years-between         datetime-provider other)
   (months-between        datetime-provider other)
   (weeks-between         datetime-provider other)
@@ -264,35 +265,47 @@
   (nanoseconds-between   datetime-provider other)
 
   (with-timezone         datetime-provider tz #:resolve-offset [resolve-offset])
-  
+
   #:defaults
   ([date?
     (define ->datetime/local at-midnight)
     (define ->datetime/utc   at-midnight)]
-    
+
    [datetime?
     (define ->datetime/local  (λ (x) x))
     (define ->datetime/utc    ->datetime/local)]
-    
+
    [moment?
+    (define/generic ->dt/l ->datetime/local)
+
     (define ->datetime/local  moment->datetime/local)
-    (define ->datetime/utc    (compose1 moment->datetime/local moment-in-utc))])
-  
+    (define ->datetime/utc    (compose1 moment->datetime/local moment-in-utc))
+
+    (define (->datetime/similar self other)
+      (->dt/l
+       (cond [(moment-provider? other)
+              (timezone-adjust other (->timezone self))]
+             [else
+              other])))])
+
   #:fallbacks
   [(define/generic ->dt ->datetime/utc)
    (define/generic ->dt/l ->datetime/local)
-   
+   (define/generic ->dt/s ->datetime/similar)
+
+   (define (->datetime/similar _ dt) (->dt/l dt))
    (define (->jd dt)    (datetime->jd (->dt dt)))
-   (define (->posix dt) (/ (nanoseconds-between (datetime 1970) dt) NS/SECOND))
-   
-   (define (lift fn)               (λ (d1 d2) (fn (->dt d1) (->dt d2))))
-   (define (quot fn n)             (λ (d1 d2) (quotient (fn d1 d2) n)))
-   
-   (define months-between          (lift datetime-months-between))
+   (define (->posix dt) (/ (nanoseconds-between (moment 1970 #:tz UTC) dt) NS/SECOND))
+
+   (define (lift/date fn) (λ (d1 d2) (fn (->dt/l d1) (->dt/s d1 d2))))
+   (define (lift/time fn) (λ (d1 d2) (fn (->dt d1) (->dt d2))))
+   (define (quot fn n)    (λ (d1 d2) (quotient (fn d1 d2) n)))
+
+   (define months-between          (lift/date datetime-months-between))
    (define years-between           (quot months-between 12))
-   (define days-between            (lift datetime-days-between))
+   (define days-between            (lift/date datetime-days-between))
    (define weeks-between           (quot days-between 7))
-   (define nanoseconds-between     (lift datetime-nanoseconds-between))
+   (define nanoseconds-between     (lift/time datetime-nanoseconds-between))
    (define hours-between           (quot nanoseconds-between NS/HOUR))
    (define minutes-between         (quot nanoseconds-between NS/MINUTE))
    (define seconds-between         (quot nanoseconds-between NS/SECOND))
@@ -309,7 +322,7 @@
   (->timezone      moment-provider)
   (->tzid          moment-provider)
   (adjust-timezone moment-provider tz)
-  
+
   #:defaults
   ([moment?
     (define ->moment        (λ (x) x))

--- a/gregor-test/gregor/tests/datetime-provider.rkt
+++ b/gregor-test/gregor/tests/datetime-provider.rkt
@@ -59,7 +59,11 @@
      (check-equal? (days-between (datetime 2000) (datetime 2001)) 366)
      (check-equal? (days-between (moment 2000 3 1 #:tz "Etc/UTC")
                                  (moment 2000 2 28 #:tz "Etc/UTC"))
-                   -2))
+                   -2)
+     ;; https://github.com/97jaz/gregor/issues/2
+     (check-equal? (days-between (moment 2015 3 29 #:tz "Europe/Berlin")
+                                 (moment 2015 3 30 #:tz "Europe/Berlin"))
+                   1))
 
    (test-case "hours-between"
      (check-equal? (hours-between (datetime 2000) (datetime 2000 1 1 13 59)) 13)


### PR DESCRIPTION
Previously, all `between` functions operated on the result
of `->datetime/utc` on their inputs. This is a problem for
moments, since it makes the date computations timezone-sensitive.
For example, the bug report I received had:

``` racket
(days-between (moment 2015 3 29 #:tz "Europe/Berlin")
              (moment 2015 3 30 #:tz "Europe/Berlin"))
```

returning 0 instead of the expected 1. That's because that day
happens to include the start of daylight saving time, so the
local timeline is missing an hour. Consequently, when we
translate these to UTC datetimes, they're within a day of each
other.

The fix is to transform the second argument into a local datetime
based on the requirements of the first argument. In most cases,
the requirements are trivial; dates and datetimes are always
transformed using `->datetime/local`, no matter what the first
argument is. But if both arguments have time zones, then the second
argument is first adjusted into the time zone of the first. Then,
the local datetime component is used.
