### PR TITLE
Fixes issue where otherwise equal datetimes have different JDs:

### DIFF
--- a/gregor-lib/gregor/private/datetime.rkt
+++ b/gregor-lib/gregor/private/datetime.rkt
@@ -26,10 +26,10 @@
   [(define equal-proc datetime-equal-proc)
    (define hash-proc  datetime-hash-proc)
    (define hash2-proc datetime-hash-proc)]
-  
+
   #:methods gen:custom-write
   [(define write-proc datetime-write-proc)]
-  
+
   #:property prop:serializable
   (make-serialize-info (λ (dt) (vector (datetime->jd dt)))
                        #'deserialize-info:DateTime
@@ -55,7 +55,7 @@
 (define (jd->datetime jd)
   (define ejd (inexact->exact jd))
   (define-values (d t) (jd->date+time ejd))
-  (DateTime d t ejd))
+  (date+time->datetime d t))
 
 (define (datetime year [month 1] [day 1] [hour 0] [minute 0] [second 0] [nano 0])
   (date+time->datetime (date year month day)
@@ -81,7 +81,7 @@
 (define (date+time->jd d t)
   (define jdn    (date->jdn d))
   (define day-ns (time->ns t))
-  
+
   (+ (- jdn 1/2)
      (/ day-ns NS/DAY)))
 
@@ -90,7 +90,7 @@
   (define d      (jdn->date jdn))
   (define day-ns (jd->day-ns jd))
   (define t      (day-ns->time day-ns))
-  
+
   (values d t))
 
 (define (jd->jdn jd)
@@ -104,7 +104,7 @@
 (define (jd->day-ns jd)
   (define base (- jd 1/2))
   (define frac (- base (exact-floor base)))
-  
+
   (exact-round (* frac NS/DAY)))
 
 (define (jd->posix jd)

--- a/gregor-test/gregor/tests/clock.rkt
+++ b/gregor-test/gregor/tests/clock.rkt
@@ -25,3 +25,23 @@
        (check-equal? (now/moment/utc) (moment 1970 1 1 0 0 1 #:tz UTC))
        (check-equal? (now/moment #:tz "America/Chicago")
                      (moment 1969 12 31 18 0 1 #:tz "America/Chicago"))))))
+
+;; https://github.com/97jaz/gregor/issues/3
+(run-tests
+ (test-suite "[round-trip ISO 8601 with clock functions]"
+   (parameterize ([current-clock (λ () 1463207954418177/1024000)])
+     (test-case "today"
+       (let ([d (today)])
+         (check-equal? d (iso8601->date (date->iso8601 d)))))
+
+     (test-case "current-time"
+       (let ([t (current-time)])
+         (check-equal? t (iso8601->time (time->iso8601 t)))))
+
+     (test-case "now"
+       (let ([n (now)])
+         (check-equal? n (iso8601->datetime (datetime->iso8601 n)))))
+
+     (test-case "now/moment"
+       (let ([n (now/moment)])
+         (check-equal? n (iso8601/tzid->moment (moment->iso8601/tzid n))))))))

--- a/gregor-test/gregor/tests/date.rkt
+++ b/gregor-test/gregor/tests/date.rkt
@@ -32,7 +32,10 @@
          (check-false (equal? (date 2000) (deserialize (serialize d3)))))))
 
    (test-case "date->iso8601"
-     (check-equal? (date->iso8601 (date 2000 6 30)) "2000-06-30"))
+     (check-equal? (date->iso8601 (date 2000 6 30)) "2000-06-30")
+
+     (let ([d (date 2000 6 30)])
+       (check-equal? (iso8601->date (date->iso8601 d)) d)))
 
    (test-suite "date order"
      (let* ([d1 (date 1950)]

--- a/gregor-test/gregor/tests/datetime.rkt
+++ b/gregor-test/gregor/tests/datetime.rkt
@@ -33,7 +33,10 @@
 
    (test-case "datetime->iso8601"
      (check-equal? (datetime->iso8601 (datetime 1969 7 21 2 56 20 1234))
-                   "1969-07-21T02:56:20.000001234"))
+                   "1969-07-21T02:56:20.000001234")
+
+     (let ([dt (datetime 2015 4 13 1 59 30 696210938)])
+       (check-equal? (iso8601->datetime (datetime->iso8601 dt)) dt)))
 
    (test-suite "datetime order"
      (let* ([t1 (datetime 0)]

--- a/gregor-test/gregor/tests/moment.rkt
+++ b/gregor-test/gregor/tests/moment.rkt
@@ -33,11 +33,17 @@
 
    (test-case "moment->iso8601"
      (check-equal? (moment->iso8601 (moment 1969 12 31 19 #:tz "America/New_York"))
-                   "1969-12-31T19:00:00-05:00"))
+                   "1969-12-31T19:00:00-05:00")
+
+     (let ([m (moment 2015 4 12 22 6 33 8026521 #:tz -14400)])
+       (check-equal? (iso8601->moment (moment->iso8601 m)) m)))
 
    (test-case "moment->iso8601/tzid"
      (check-equal? (moment->iso8601/tzid (moment 1969 12 31 19 #:tz "America/New_York"))
-                   "1969-12-31T19:00:00-05:00[America/New_York]"))
+                   "1969-12-31T19:00:00-05:00[America/New_York]")
+
+     (let ([m (moment 2015 4 12 22 6 33 8026521 #:tz "America/New_York")])
+       (check-equal? (iso8601/tzid->moment (moment->iso8601/tzid m)) m)))
 
    (test-suite "moment order"
      (let* ([t1 (moment -1000)]

--- a/gregor-test/gregor/tests/time.rkt
+++ b/gregor-test/gregor/tests/time.rkt
@@ -3,6 +3,7 @@
 (require rackunit
          rackunit/text-ui
          racket/serialize
+         gregor
          gregor/time)
 
 (run-tests
@@ -32,7 +33,10 @@
          (check-false (equal? (time 12) (deserialize (serialize t3)))))))
 
    (test-case "time->iso8601"
-     (check-equal? (time->iso8601 (time 12 45 3 1234)) "12:45:03.000001234"))
+     (check-equal? (time->iso8601 (time 12 45 3 1234)) "12:45:03.000001234")
+
+     (let ([t (time 1 56 43 386282959)])
+       (check-equal? (iso8601->time (time->iso8601 t)) t)))
 
    (test-suite "time order"
      (let* ([t1 (time 0)]


### PR DESCRIPTION
`date+time->datetime` and `posix->datetime` were computing the JD
in different ways (because it was more efficient that way).
Unfortunately, the different methods of computation don't give
the same results, so now `posix->datetime` has to do a bit more
work.

Of course, storing the JD in the datetime struct isn't necessary.
Caching it is a performance win in some cases and a loss in others.
