### PR TITLE
Fixes #14: bug in posix->moment with UTC offset TZs

### DIFF
--- a/gregor-lib/gregor/private/moment.rkt
+++ b/gregor-lib/gregor/private/moment.rkt
@@ -54,11 +54,13 @@
             moment-in-utc))
 
 (define (posix->moment p z)
-  (define off
-    (cond [(string? z) (tzoffset-utc-seconds (utc-seconds->tzoffset z p))]
-          [else        z]))
+  (define-values (off tzid)
+    (cond [(string? z)
+           (values (tzoffset-utc-seconds (utc-seconds->tzoffset z p)) z)]
+          [else
+           (values z #f)]))
   (define dt (posix->datetime (+ p off)))
-  (make-moment dt off z))
+  (make-moment dt off tzid))
 
 (define (moment-add-nanoseconds m n)
   (posix->moment (+ (moment->posix m) (* n (/ 1 NS/SECOND)))

--- a/gregor-test/gregor/tests/clock.rkt
+++ b/gregor-test/gregor/tests/clock.rkt
@@ -11,20 +11,25 @@
 
      (test-case "today"
        (check-equal? (today/utc) (date 1970))
-       (check-equal? (today #:tz "America/Chicago") (date 1969 12 31)))
+       (check-equal? (today #:tz "America/Chicago") (date 1969 12 31))
+       (check-equal? (today #:tz -21600) (date 1969 12 31)))
 
      (test-case "current-time"
        (check-equal? (current-time/utc) (time 0 0 1))
-       (check-equal? (current-time #:tz "America/Chicago") (time 18 0 1)))
+       (check-equal? (current-time #:tz "America/Chicago") (time 18 0 1))
+       (check-equal? (current-time #:tz -21600) (time 18 0 1)))
 
      (test-case "now"
        (check-equal? (now/utc) (datetime 1970 1 1 0 0 1))
-       (check-equal? (now #:tz "America/Chicago") (datetime 1969 12 31 18 0 1)))
+       (check-equal? (now #:tz "America/Chicago") (datetime 1969 12 31 18 0 1))
+       (check-equal? (now #:tz -21600) (datetime 1969 12 31 18 0 1)))
 
      (test-case "moment"
        (check-equal? (now/moment/utc) (moment 1970 1 1 0 0 1 #:tz UTC))
        (check-equal? (now/moment #:tz "America/Chicago")
-                     (moment 1969 12 31 18 0 1 #:tz "America/Chicago"))))))
+                     (moment 1969 12 31 18 0 1 #:tz "America/Chicago"))
+       (check-equal? (now/moment #:tz -21600)
+                     (moment 1969 12 31 18 0 1 #:tz -21600))))))
 
 ;; https://github.com/97jaz/gregor/issues/3
 (run-tests

--- a/gregor-test/gregor/tests/date-arithmetic.rkt
+++ b/gregor-test/gregor/tests/date-arithmetic.rkt
@@ -16,7 +16,10 @@
      (check-equal? (+years (moment 2014 3 8 2 #:tz "America/New_York") 1)
                    (moment 2015 3 8 3 #:tz "America/New_York"))
      (check-equal? (+years (moment 2016 3 8 2 #:tz "America/New_York") -1)
-                   (moment 2015 3 8 3 #:tz "America/New_York")))
+                   (moment 2015 3 8 3 #:tz "America/New_York"))
+     (check-equal? (+years (moment 2016 3 8 2 #:tz -18000) -1)
+                   (moment 2015 3 8 2 #:tz -18000)))
+
 
    (test-case "-years"
      (check-equal? (-years (date 1970) -4) (date 1974))
@@ -27,6 +30,8 @@
                    (moment 2015 3 8 3 #:tz "America/New_York"))
      (check-equal? (-years (moment 2016 3 8 2 #:tz "America/New_York") 1)
                    (moment 2015 3 8 3 #:tz "America/New_York"))
+     (check-equal? (-years (moment 2016 3 8 2 #:tz -18000) 1)
+                   (moment 2015 3 8 2 #:tz -18000))
 
      (check-exn exn:gregor:invalid-offset?
                 (λ ()
@@ -42,7 +47,9 @@
      (check-equal? (+months (moment 2015 2 8 2 #:tz "America/New_York") 1)
                    (moment 2015 3 8 3 #:tz "America/New_York"))
      (check-equal? (+months (moment 2015 4 8 2 #:tz "America/New_York") -1)
-                   (moment 2015 3 8 3 #:tz "America/New_York")))
+                   (moment 2015 3 8 3 #:tz "America/New_York"))
+     (check-equal? (+months (moment 2015 4 8 2 #:tz -14400) -1)
+                   (moment 2015 3 8 2 #:tz -14400)))
 
    (test-case "-months"
      (check-equal? (-months (date 1970) -4) (date 1970 5))
@@ -52,7 +59,9 @@
      (check-equal? (-months (moment 2015 2 8 2 #:tz "America/New_York") -1)
                    (moment 2015 3 8 3 #:tz "America/New_York"))
      (check-equal? (-months (moment 2015 4 8 2 #:tz "America/New_York") 1)
-                   (moment 2015 3 8 3 #:tz "America/New_York")))
+                   (moment 2015 3 8 3 #:tz "America/New_York"))
+     (check-equal? (-months (moment 2015 4 8 2 #:tz -14400) 1)
+                   (moment 2015 3 8 2 #:tz -14400)))
 
    (test-case "+weeks"
      (check-equal? (+weeks (date 1970) 6) (date 1970 2 12))
@@ -64,7 +73,9 @@
                       #:tz "America/Los_Angeles"
                       #:resolve-offset resolve-offset/raise)
               1)
-      (moment 2015 3 8 3 #:tz "America/Los_Angeles")))
+      (moment 2015 3 8 3 #:tz "America/Los_Angeles"))
+     (check-equal? (+weeks (moment 2015 3 1 #:tz -18000) 1)
+                   (moment 2015 3 8 #:tz -18000)))
 
    (test-case "-weeks"
      (check-equal? (-weeks (date 1970) -6) (date 1970 2 12))
@@ -76,7 +87,9 @@
                       #:tz "America/Los_Angeles"
                       #:resolve-offset resolve-offset/raise)
               -1)
-      (moment 2015 3 8 3 #:tz "America/Los_Angeles")))
+      (moment 2015 3 8 3 #:tz "America/Los_Angeles"))
+     (check-equal? (-weeks (moment 2015 3 8 #:tz -18000) 1)
+                   (moment 2015 3 1 #:tz -18000)))
 
    (test-case "+days"
      (check-equal? (+days (date 1980) (* 365 2)) (date 1981 12 31))
@@ -85,7 +98,9 @@
                 (λ ()
                   (+days (moment 2015 3 7 2 #:tz "America/Denver")
                          1
-                         #:resolve-offset resolve-offset/raise))))
+                         #:resolve-offset resolve-offset/raise)))
+     (check-equal? (+days (moment 2015 3 7 2 #:tz -25200) 1)
+                   (moment 2015 3 8 2 #:tz -25200)))
 
    (test-case "-days"
      (check-equal? (-days (date 1980) (* 365 -2)) (date 1981 12 31))
@@ -94,15 +109,19 @@
                 (λ ()
                   (-days (moment 2015 3 7 2 #:tz "America/Denver")
                          -1
-                         #:resolve-offset resolve-offset/raise))))
+                         #:resolve-offset resolve-offset/raise)))
+     (check-equal? (-days (moment 2015 3 8 2 #:tz -25200) 1)
+                   (moment 2015 3 7 2 #:tz -25200)))
 
    (test-case "+date-period"
      (check-equal? (+date-period (date 1980 6 5) (days 10)) (date 1980 6 15))
      (check-equal? (+date-period (datetime 2000 10 10) (weeks -2)) (datetime 2000 9 26))
      (check-equal? (+date-period (moment 2015 8 30) (months 23)) (moment 2017 7 30))
+     (check-equal? (+date-period (moment 2015 8 30 #:tz 0) (months 23)) (moment 2017 7 30 #:tz 0))
      (check-equal? (+date-period (date 1990) (years 10)) (date 2000))
      (check-equal? (+date-period (date 1950) (period [years 6] [months 2] [days 15])) (date 1956 3 16)))
 
    (test-case "-date-period"
      (check-equal? (-date-period (date 1956 3 16) (period [years 6] [months 2] [days 15])) (date 1950))
-     (check-equal? (-date-period (datetime 1956 3 16) (period [years 6] [months 2] [days 15])) (datetime 1950)))))
+     (check-equal? (-date-period (datetime 1956 3 16) (period [years 6] [months 2] [days 15])) (datetime 1950))
+     (check-equal? (-date-period (moment 2017 7 30 #:tz 0) (months 23)) (moment 2015 8 30 #:tz 0)))))

--- a/gregor-test/gregor/tests/datetime-arithmetic.rkt
+++ b/gregor-test/gregor/tests/datetime-arithmetic.rkt
@@ -13,8 +13,12 @@
      (check-equal? (+period (datetime 1970) (period [years 5] [hours 2]))
                    (datetime 1975 1 1 2 0))
      (check-equal? (+period (moment 1970 #:tz "UTC") (period [years 5] [hours 2]))
-                   (moment 1975 1 1 2 0 #:tz "UTC")))
+                   (moment 1975 1 1 2 0 #:tz "UTC"))
+     (check-equal? (+period (moment 1970 #:tz 0) (period [years 5] [hours 2]))
+                   (moment 1975 1 1 2 0 #:tz 0)))
 
    (test-case "-period"
      (check-equal? (-period (datetime 2010 12 10 18) (period [years 1] [weeks -2] [minutes 100]))
-                   (-minutes (+weeks (-years (datetime 2010 12 10 18) 1) 2) 100)))))
+                   (-minutes (+weeks (-years (datetime 2010 12 10 18) 1) 2) 100))
+     (check-equal? (-period (moment 2010 12 10 18 #:tz 0) (period [years 1] [weeks -2] [minutes 100]))
+                   (-minutes (+weeks (-years (moment 2010 12 10 18 #:tz 0) 1) 2) 100)))))

--- a/gregor-test/gregor/tests/datetime-provider.rkt
+++ b/gregor-test/gregor/tests/datetime-provider.rkt
@@ -10,25 +10,31 @@
 
    (test-case "datetime-provider?"
      (check-true (datetime-provider? (datetime 2000)))
-     (check-true (datetime-provider? (moment 2000))))
+     (check-true (datetime-provider? (moment 2000)))
+     (check-true (datetime-provider? (moment 2000 #:tz 0))))
 
    (test-case "->datetime/local"
      (check-equal? (->datetime/local (datetime 2000)) (datetime 2000))
-     (check-equal? (->datetime/local (moment 2000 #:tz "America/New_York")) (datetime 2000)))
+     (check-equal? (->datetime/local (moment 2000 #:tz "America/New_York")) (datetime 2000))
+     (check-equal? (->datetime/local (moment 2000 #:tz -18000)) (datetime 2000)))
 
    (test-case "->datetime/utc"
      (check-equal? (->datetime/utc (datetime 2000)) (datetime 2000))
      (check-equal? (->datetime/utc (moment 2000 #:tz "America/New_York"))
+                   (datetime 2000 1 1 5))
+     (check-equal? (->datetime/utc (moment 2000 #:tz -18000))
                    (datetime 2000 1 1 5)))
 
    (test-case "->posix"
      (check-equal? (->posix (datetime 1970)) 0)
      (check-equal? (->posix (moment 1970 #:tz "Etc/UTC")) 0)
-     (check-equal? (->posix (moment 1950 6 20 #:tz "America/New_York")) -616449600))
+     (check-equal? (->posix (moment 1950 6 20 #:tz "America/New_York")) -616449600)
+     (check-equal? (->posix (moment 1950 6 20 #:tz -14400)) -616449600))
 
    (test-case "->jd"
      (check-equal? (->jd (datetime 1970)) (+ 2440587 1/2))
-     (check-equal? (->jd (moment 2014 12 8 7 #:tz "America/New_York")) 2457000))
+     (check-equal? (->jd (moment 2014 12 8 7 #:tz "America/New_York")) 2457000)
+     (check-equal? (->jd (moment 2014 12 8 7 #:tz -18000)) 2457000))
 
    (test-case "years-between"
      (check-equal? (years-between (datetime 0) (datetime 0)) 0)
@@ -37,14 +43,23 @@
      (check-equal? (years-between (moment 2000 #:tz "America/New_York")
                                   (moment 2001 #:tz "Etc/UTC"))
                    0)
+     (check-equal? (years-between (moment 2000 #:tz -18000)
+                                  (moment 2001 #:tz 0))
+                   0)
      (check-equal? (years-between (moment 2000 #:tz "America/New_York")
                                   (moment 2001 1 1 5 #:tz "Etc/UTC"))
+                   1)
+     (check-equal? (years-between (moment 2000 #:tz "America/New_York")
+                                  (moment 2001 1 1 5 #:tz 0))
                    1))
 
    (test-case "months-between"
      (check-equal? (months-between (datetime 1970 1 1) (datetime 1968 6 20))
                    -18)
      (check-equal? (months-between (moment 2000 #:tz "Etc/UTC")
+                                   (moment 2000 4 #:tz "America/New_York"))
+                   3)
+     (check-equal? (months-between (moment 2000 #:tz 0)
                                    (moment 2000 4 #:tz "America/New_York"))
                    3))
 
@@ -53,6 +68,9 @@
                    -10)
      (check-equal? (weeks-between (moment 2015 3 15 #:tz "America/New_York")
                                   (moment 2015 5 29 #:tz "America/New_York"))
+                   10)
+     (check-equal? (weeks-between (moment 2015 3 15 #:tz -14400)
+                                  (moment 2015 5 29 #:tz -14400))
                    10))
 
    (test-case "days-between"
@@ -63,7 +81,10 @@
      ;; https://github.com/97jaz/gregor/issues/2
      (check-equal? (days-between (moment 2015 3 29 #:tz "Europe/Berlin")
                                  (moment 2015 3 30 #:tz "Europe/Berlin"))
-                   1))
+                   1)
+     (check-equal? (days-between (moment 2015 3 29 #:tz 3600)
+                                 (moment 2015 3 30 #:tz 7200))
+                   0))
 
    (test-case "hours-between"
      (check-equal? (hours-between (datetime 2000) (datetime 2000 1 1 13 59)) 13)
@@ -72,17 +93,26 @@
                    1)
      (check-equal? (hours-between (moment 2015 3 8 1 #:tz "Etc/UTC")
                                   (moment 2015 3 8 3 #:tz "Etc/UTC"))
+                   2)
+     (check-equal? (hours-between (moment 2015 3 8 1 #:tz 0)
+                                  (moment 2015 3 8 3 #:tz 0))
                    2))
 
    (test-case "minutes-between"
      (check-equal? (minutes-between (datetime 2000) (datetime 2000 1 1 1)) 60)
      (check-equal? (minutes-between (moment 2000 #:tz "America/New_York")
                                     (moment 2000 #:tz "Etc/UTC"))
+                   -300)
+     (check-equal? (minutes-between (moment 2000 #:tz -18000)
+                                    (moment 2000 #:tz 0))
                    -300))
 
    (test-case "seconds-between"
      (check-equal? (seconds-between (datetime 2000) (datetime 2000 1 1 1)) 3600)
      (check-equal? (seconds-between (moment 2000 #:tz "America/New_York")
+                                    (moment 2000 #:tz "Etc/UTC"))
+                   -18000)
+     (check-equal? (seconds-between (moment 2000 #:tz -18000)
                                     (moment 2000 #:tz "Etc/UTC"))
                    -18000))
 
@@ -90,16 +120,25 @@
      (check-equal? (milliseconds-between (datetime 2000) (datetime 2000 1 1 1)) 3600000)
      (check-equal? (milliseconds-between (moment 2000 #:tz "America/New_York")
                                          (moment 2000 #:tz "Etc/UTC"))
+                   -18000000)
+     (check-equal? (milliseconds-between (moment 2000 #:tz "America/New_York")
+                                         (moment 2000 #:tz 0))
                    -18000000))
 
    (test-case "microseconds-between"
      (check-equal? (microseconds-between (datetime 2000) (datetime 2000 1 1 1)) 3600000000)
      (check-equal? (microseconds-between (moment 2000 #:tz "America/New_York")
                                          (moment 2000 #:tz "Etc/UTC"))
+                   -18000000000)
+     (check-equal? (microseconds-between (moment 2000 #:tz -18000)
+                                         (moment 2000 #:tz 0))
                    -18000000000))
 
    (test-case "nanoseconds-between"
      (check-equal? (nanoseconds-between (datetime 2000) (datetime 2000 1 1 1)) 3600000000000)
      (check-equal? (nanoseconds-between (moment 2000 #:tz "America/New_York")
                                         (moment 2000 #:tz "Etc/UTC"))
+                   -18000000000000)
+     (check-equal? (nanoseconds-between (moment 2000 #:tz -18000)
+                                        (moment 2000 #:tz 0))
                    -18000000000000))))

--- a/gregor-test/gregor/tests/moment-provider.rkt
+++ b/gregor-test/gregor/tests/moment-provider.rkt
@@ -10,11 +10,14 @@
 
    (test-case "moment-provider?"
      (check-true (moment-provider? (moment 2000 #:tz "Etc/UTC")))
+     (check-true (moment-provider? (moment 2000 #:tz -18000)))
      (check-false (moment-provider? (datetime 2000))))
 
    (test-case "->moment"
      (check-equal? (->moment (moment 2000 #:tz "America/New_York"))
-                   (moment 2000 #:tz "America/New_York")))
+                   (moment 2000 #:tz "America/New_York"))
+     (check-equal? (->moment (moment 2000 #:tz -18000))
+                   (moment 2000 #:tz -18000)))
 
    (test-case "->utc-offset"
      (check-equal? (->utc-offset (moment 2000 #:tz "America/New_York"))
@@ -38,6 +41,10 @@
    (test-case "adjust-timezone"
      (check-equal? (adjust-timezone
                     (moment 2000 #:tz "America/New_York")
+                    "Etc/UTC")
+                   (moment 2000 1 1 5 #:tz "Etc/UTC"))
+     (check-equal? (adjust-timezone
+                    (moment 2000 #:tz -18000)
                     "Etc/UTC")
                    (moment 2000 1 1 5 #:tz "Etc/UTC"))
      (check-equal? (adjust-timezone

--- a/gregor-test/gregor/tests/moment.rkt
+++ b/gregor-test/gregor/tests/moment.rkt
@@ -15,20 +15,24 @@
    (test-suite "moment struct"
      (let* ([t1 (moment 1970 #:tz "Etc/UTC")]
             [t2 (moment 1969 12 31 19 #:tz "America/New_York")]
-            [t3 (moment 1969 12 31 16 #:tz "America/Los_Angeles")])
+            [t3 (moment 1969 12 31 16 #:tz "America/Los_Angeles")]
+            [t4 (moment 1969 12 31 19 #:tz -18000)])
 
        (test-case "temporal equality"
          (check-true (moment=? t1 t2))
          (check-true (moment=? t1 t3))
+         (check-true (moment=? t1 t4))
          (check-false (moment=? t1 (moment 2015 #:tz "Etc/UTC"))))
 
        (test-case "structural equality"
          (check-true (equal? t1 (moment 1970 1 1 #:tz "Etc/UTC")))
          (check-false (equal? t1 t2))
+         (check-false (equal? t1 t4))
          (check-false (equal? t1 t3)))
 
        (test-case "serializability"
          (check-true (equal? t1 (deserialize (serialize t1))))
+         (check-true (equal? t4 (deserialize (serialize t4))))
          (check-false (equal? (moment 2015 #:tz "Etc/UTC") (deserialize (serialize t3)))))))
 
    (test-case "moment->iso8601"

--- a/gregor-test/gregor/tests/time-arithmetic.rkt
+++ b/gregor-test/gregor/tests/time-arithmetic.rkt
@@ -14,88 +14,120 @@
      (check-equal? (+hours (time 12) -4) (time 8))
      (check-equal? (+hours (datetime 2000 2 2 15 30 20) 26) (datetime 2000 2 3 17 30 20))
      (check-equal? (+hours (moment 2015 3 8 1 #:tz "America/New_York") 1)
-                   (moment 2015 3 8 3 #:tz "America/New_York")))
+                   (moment 2015 3 8 3 #:tz "America/New_York"))
+     (check-equal? (+hours (moment 2015 3 8 1 #:tz -18000) 1)
+                   (moment 2015 3 8 2 #:tz -18000)))
 
    (test-case "-hours"
      (check-equal? (-hours (time 0) 36) (time 12))
      (check-equal? (-hours (time 12) -4) (time 16))
      (check-equal? (-hours (datetime 2000 2 2 15 30 20) 26) (datetime 2000 2 1 13 30 20))
      (check-equal? (-hours (moment 2015 3 8 3 #:tz "America/New_York") 1)
-                   (moment 2015 3 8 1 #:tz "America/New_York")))
+                   (moment 2015 3 8 1 #:tz "America/New_York"))
+     (check-equal? (-hours (moment 2015 3 8 2 #:tz -18000) 1)
+                   (moment 2015 3 8 1 #:tz -18000)))
 
    (test-case "+minutes"
      (check-equal? (+minutes (time 0) 121) (time 2 1))
      (check-equal? (+minutes (datetime 2000 2 28 23 59) 1) (datetime 2000 2 29))
      (check-equal? (+minutes (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1969 12 31 23 48 #:tz "Etc/UTC")))
+                   (moment 1969 12 31 23 48 #:tz "Etc/UTC"))
+     (check-equal? (+minutes (moment 1970 #:tz 0) -12)
+                   (moment 1969 12 31 23 48 #:tz 0)))
 
    (test-case "-minutes"
      (check-equal? (-minutes (time 0) 121) (time 21 59))
      (check-equal? (-minutes (datetime 2000 2 29) 1) (datetime 2000 2 28 23 59) 1)
      (check-equal? (-minutes (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1970 1 1 0 12 #:tz "Etc/UTC")))
+                   (moment 1970 1 1 0 12 #:tz "Etc/UTC"))
+     (check-equal? (-minutes (moment 1970 #:tz 0) -12)
+                   (moment 1970 1 1 0 12 #:tz 0)))
 
    (test-case "+seconds"
      (check-equal? (+seconds (time 0) 121) (time 0 2 1))
      (check-equal? (+seconds (datetime 2000 2 28 23 59 59) 1) (datetime 2000 2 29))
      (check-equal? (+seconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1969 12 31 23 59 48 #:tz "Etc/UTC")))
+                   (moment 1969 12 31 23 59 48 #:tz "Etc/UTC"))
+     (check-equal? (+seconds (moment 1970 #:tz 0) -12)
+                   (moment 1969 12 31 23 59 48 #:tz 0)))
 
    (test-case "-seconds"
      (check-equal? (-seconds (time 0) 121) (time 23 57 59))
      (check-equal? (-seconds (datetime 2000 2 29) 1) (datetime 2000 2 28 23 59 59) 1)
      (check-equal? (-seconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1970 1 1 0 0 12 #:tz "Etc/UTC")))
+                   (moment 1970 1 1 0 0 12 #:tz "Etc/UTC"))
+     (check-equal? (-seconds (moment 1970 #:tz 0) -12)
+                   (moment 1970 1 1 0 0 12 #:tz 0)))
 
    (test-case "+milliseconds"
      (check-equal? (+milliseconds (time 0) 121) (time 0 0 0 121000000))
      (check-equal? (+milliseconds (datetime 2000 2 28 23 59 59) 1)
                    (datetime 2000 2 28 23 59 59 1000000))
      (check-equal? (+milliseconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1969 12 31 23 59 59 988000000 #:tz "Etc/UTC")))
+                   (moment 1969 12 31 23 59 59 988000000 #:tz "Etc/UTC"))
+     (check-equal? (+milliseconds (moment 1970 #:tz 0) -12)
+                   (moment 1969 12 31 23 59 59 988000000 #:tz 0)))
 
    (test-case "-milliseconds"
      (check-equal? (-milliseconds (time 0) 121) (time 23 59 59 879000000))
      (check-equal? (-milliseconds (datetime 2000 2 29) 1)
                    (datetime 2000 2 28 23 59 59 999000000))
      (check-equal? (-milliseconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1970 1 1 0 0 0 12000000 #:tz "Etc/UTC")))
+                   (moment 1970 1 1 0 0 0 12000000 #:tz "Etc/UTC"))
+     (check-equal? (-milliseconds (moment 1970 #:tz 0) -12)
+                   (moment 1970 1 1 0 0 0 12000000 #:tz 0)))
 
    (test-case "+mircoseconds"
      (check-equal? (+microseconds (time 0) 121) (time 0 0 0 121000))
      (check-equal? (+microseconds (datetime 2000 2 28 23 59 59) 1)
                    (datetime 2000 2 28 23 59 59 1000))
      (check-equal? (+microseconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1969 12 31 23 59 59 999988000 #:tz "Etc/UTC")))
+                   (moment 1969 12 31 23 59 59 999988000 #:tz "Etc/UTC"))
+     (check-equal? (+microseconds (moment 1970 #:tz 0) -12)
+                   (moment 1969 12 31 23 59 59 999988000 #:tz 0)))
 
    (test-case "-microseconds"
      (check-equal? (-microseconds (time 0) 121) (time 23 59 59 999879000))
      (check-equal? (-microseconds (datetime 2000 2 29) 1)
                    (datetime 2000 2 28 23 59 59 999999000))
      (check-equal? (-microseconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1970 1 1 0 0 0 12000 #:tz "Etc/UTC")))
+                   (moment 1970 1 1 0 0 0 12000 #:tz "Etc/UTC"))
+     (check-equal? (-microseconds (moment 1970 #:tz 0) -12)
+                   (moment 1970 1 1 0 0 0 12000 #:tz 0)))
 
    (test-case "+nanoseconds"
      (check-equal? (+nanoseconds (time 0) 121) (time 0 0 0 121))
      (check-equal? (+nanoseconds (datetime 2000 2 28 23 59 59) 1)
                    (datetime 2000 2 28 23 59 59 1))
      (check-equal? (+nanoseconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1969 12 31 23 59 59 999999988 #:tz "Etc/UTC")))
+                   (moment 1969 12 31 23 59 59 999999988 #:tz "Etc/UTC"))
+     (check-equal? (+nanoseconds (moment 1970 #:tz 0) -12)
+                   (moment 1969 12 31 23 59 59 999999988 #:tz 0)))
 
    (test-case "-nanoseconds"
      (check-equal? (-nanoseconds (time 0) 121) (time 23 59 59 999999879))
      (check-equal? (-nanoseconds (datetime 2000 2 29) 1)
                    (datetime 2000 2 28 23 59 59 999999999))
      (check-equal? (-nanoseconds (moment 1970 #:tz "Etc/UTC") -12)
-                   (moment 1970 1 1 0 0 0 12 #:tz "Etc/UTC")))
+                   (moment 1970 1 1 0 0 0 12 #:tz "Etc/UTC"))
+     (check-equal? (-nanoseconds (moment 1970 #:tz 0) -12)
+                   (moment 1970 1 1 0 0 0 12 #:tz 0)))
 
    (test-case "+time-period"
      (check-equal? (+time-period (time 15 30) (hours -70)) (-hours (time 15 30) 70))
      (check-equal? (+time-period (datetime 2000 9 9 8 30 28 6789) (period [hours -345] [minutes 7364] [seconds 9907] [nanoseconds -3000000000000]))
-                   (-nanoseconds (+seconds (+minutes (-hours (datetime 2000 9 9 8 30 28 6789) 345) 7364) 9907) 3000000000000)))
+                   (-nanoseconds (+seconds (+minutes (-hours (datetime 2000 9 9 8 30 28 6789) 345) 7364) 9907) 3000000000000))
+     (check-equal? (+time-period (moment 1970 #:tz "Etc/UTC") (period [hours 8] [minutes 10]))
+                   (moment 1970 1 1 8 10 #:tz "Etc/UTC"))
+     (check-equal? (+time-period (moment 1970 #:tz 0) (period [hours 8] [minutes 10]))
+                   (moment 1970 1 1 8 10 #:tz 0)))
 
    (test-case "-time-period"
      (check-equal? (-time-period (time 15 30) (hours 70)) (+hours (time 15 30) -70))
      (check-equal? (-time-period (datetime 2000 9 9 8 30 28 6789)
                                  (negate-period (period [hours -345] [minutes 7364] [seconds 9907] [nanoseconds -3000000000000])))
-                   (-nanoseconds (+seconds (+minutes (-hours (datetime 2000 9 9 8 30 28 6789) 345) 7364) 9907) 3000000000000)))))
+                   (-nanoseconds (+seconds (+minutes (-hours (datetime 2000 9 9 8 30 28 6789) 345) 7364) 9907) 3000000000000))
+     (check-equal? (-time-period (moment 1970 1 1 8 10 #:tz "Etc/UTC") (period [hours 8] [minutes 10]))
+                   (moment 1970 #:tz "Etc/UTC"))
+     (check-equal? (-time-period (moment 1970 1 1 8 10 #:tz 0) (period [hours 8] [minutes 10]))
+                   (moment 1970 #:tz 0)))))


### PR DESCRIPTION
@jackfirth This should address your issue #14. I'll wait on merging it for a while to give you a chance to look it over, if you want.

The fix itself is simple. Most of the added code is to provide better test coverage for `moment`s that use UTC offsets as time zones.
