### PR TITLE
parse-date: explain why data is insufficient in error message

### DIFF
--- a/gregor-lib/gregor/private/pattern/parse-state.rkt
+++ b/gregor-lib/gregor/private/pattern/parse-state.rkt
@@ -40,7 +40,7 @@
   (match-define (fields era year month day period hour minute second nano offset tzid)
     fs)
 
-  (unless year (err "Insufficient data in input to construct a temporal object"))
+  (unless year (err "Insufficient data in input to construct a temporal object; missing year"))
 
   (define y (if (= 0 era) (add1 (- year)) year))
   (define m (or month 1))


### PR DESCRIPTION
This is a tiny change to the error message. If you don't mind a bigger change, I can update this to something like:

> Failed to parse year from input, cannot construct a temporal object