### PR TITLE
Bugfix 23

### DIFF
--- a/gregor-lib/gregor/private/period.rkt
+++ b/gregor-lib/gregor/private/period.rkt
@@ -75,10 +75,7 @@
        (andmap (λ (fstx) (field->accessor fstx)) (syntax->list #'(field ...)))
        (with-syntax ([(accessor ...) (map field->accessor (syntax->list #'(field ...)))])
          #`(and (app accessor pat) ...))]))
-  (λ (stx)
-    (syntax-case stx ()
-      [(_ xs ...) #'(period xs ...)]
-      [_ #'period])))
+  (make-rename-transformer #'period))
 
 (define date-period? Period-dp?)
 (define time-period? Period-tp?)


### PR DESCRIPTION
Macros like fancy-app supply their own version of `#%app`.  Expanding the clause `[(_ xs ...) #'(period xs ...)]` uses the `#%app` from `racket/base`.  Using a rename-transformer avoids introducing this.