### PR TITLE
rename `build-comparison` functions

### DIFF
--- a/gregor-lib/gregor/private/core/compare.rkt
+++ b/gregor-lib/gregor/private/core/compare.rkt
@@ -1,33 +1,51 @@
 #lang racket/base
 
-(require data/order)
+(require data/order
+         (for-syntax racket/base
+                     syntax/parse
+                     racket/syntax))
 
-(provide (all-defined-out))
+(provide
+  (struct-out comparison)
+  build-comparison)
 
 (struct comparison (=? <? <=? >? >=? comparator order))
 
-(define (build-comparison name pred? ->num)
-  (define (comparator x y)
-    (define diff (- (->num x) (->num y)))
-  
-    (cond [(negative? diff) '<]
-          [(zero? diff)     '=]
-          [else             '>]))
-         
-  (define (=? x y) (eq? '= (comparator x y)))
-  (define (<? x y) (eq? '< (comparator x y)))
-  (define (>? x y) (eq? '> (comparator x y)))
-  
-  (define (<=? x y)
-    (case (comparator x y)
-      [(< =) #t]
-      [else  #f]))
-  
-  (define (>=? x y)
-    (case (comparator x y)
-      [(> =) #t]
-      [else  #f]))
+(define-syntax (build-comparison stx)
+  (syntax-parse stx #:literals (quote)
+    [(_ (quote name-prefix:id) pred?:id ->num:id)
+     #:with comparator-id (id/suffix #'name-prefix '-comparator)
+     #:with =?-id (id/suffix #'name-prefix '=?)
+     #:with <?-id (id/suffix #'name-prefix '<?)
+     #:with >?-id (id/suffix #'name-prefix '>?)
+     #:with <=?-id (id/suffix #'name-prefix '<=?)
+     #:with >=?-id (id/suffix #'name-prefix '>=?)
+     #:with order-id (id/suffix #'name-prefix '-order)
+     #'(let ()
+         (define (comparator-id x y)
+           (define diff (- (->num x) (->num y)))
+           (cond [(negative? diff) '<]
+                 [(zero? diff)     '=]
+                 [else             '>]))
 
-  (define the-order (order name pred? comparator))
-  
-  (comparison =? <? <=? >? >=? comparator the-order))
+         (define (=?-id x y) (eq? '= (comparator-id x y)))
+         (define (<?-id x y) (eq? '< (comparator-id x y)))
+         (define (>?-id x y) (eq? '> (comparator-id x y)))
+
+         (define (<=?-id x y)
+           (case (comparator-id x y)
+             [(< =) #t]
+             [else  #f]))
+
+         (define (>=?-id x y)
+           (case (comparator-id x y)
+             [(> =) #t]
+             [else  #f]))
+
+         (define order-id (order 'order-id pred? comparator-id))
+
+         (comparison =?-id <?-id <=?-id >?-id >=?-id comparator-id order-id))]))
+
+(define-for-syntax (id/suffix id sym)
+  (format-id id "~a~a" id sym))
+

--- a/gregor-lib/gregor/private/date.rkt
+++ b/gregor-lib/gregor/private/date.rkt
@@ -80,7 +80,7 @@
     [(YMD y m d) (format "~a-~a-~a" (f y 4) (f m 2) (f d 2))]))
 
 (match-define (comparison date=? date<? date<=? date>? date>=? date-compare date-order)
-  (build-comparison 'date-order date? date->jdn))
+  (build-comparison 'date date? date->jdn))
 
 (define deserialize-info:Date
   (make-deserialize-info

--- a/gregor-lib/gregor/private/datetime.rkt
+++ b/gregor-lib/gregor/private/datetime.rkt
@@ -67,7 +67,7 @@
           (time->iso8601 (datetime->time dt))))
 
 (match-define (comparison datetime=? datetime<? datetime<=? datetime>? datetime>=? datetime-comparator datetime-order)
-  (build-comparison 'datetime-order datetime? datetime->jd))
+  (build-comparison 'datetime datetime? datetime->jd))
 
 (define deserialize-info:DateTime
   (make-deserialize-info

--- a/gregor-lib/gregor/private/moment.rkt
+++ b/gregor-lib/gregor/private/moment.rkt
@@ -84,7 +84,7 @@
   (datetime+tz->moment (moment->datetime/local m) z resolve))
 
 (match-define (comparison moment=? moment<? moment<=? moment>? moment>=? moment-comparator moment-order)
-  (build-comparison 'moment-order moment? moment->jd))
+  (build-comparison 'moment moment? moment->jd))
 
 (define UTC "Etc/UTC")
 

--- a/gregor-lib/gregor/private/time.rkt
+++ b/gregor-lib/gregor/private/time.rkt
@@ -58,7 +58,7 @@
   (format "~a:~a:~a~a" (f h 2) (f m 2) pad (~r fsec #:precision 9)))
 
 (match-define (comparison time=? time<? time<=? time>? time>=? time-comparator time-order)
-  (build-comparison 'time-order time? time->ns))
+  (build-comparison 'time time? time->ns))
 
 (define deserialize-info:Time
   (make-deserialize-info


### PR DESCRIPTION
Use the first argument to rename the =? <? .... functions.

EDIT: the original example in this pull request was bad

This helps improve error messages that use `object-name`, for
 example arity errors:

```
(require gregor)
(date<? 0)
```

Also `(displayln date<?)`