### PR TITLE
Adds max length constraints for many parsing patterns

### DIFF
--- a/gregor-lib/gregor/private/pattern/ast/day.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/day.rkt
@@ -21,11 +21,11 @@
 (define (day-parse ast state ci? loc)
   (match ast
     [(Day _ 'month n)
-     (num-parse ast loc state (parse-state/ day) #:min n #:ok? (between/c 1 31))]
+     (num-parse ast loc state (parse-state/ day) #:min n #:max 2 #:ok? (between/c 1 31))]
     [(Day _ 'year n)
-     (num-parse ast loc state parse-state/ignore #:min n #:ok? (between/c 1 366))]
+     (num-parse ast loc state parse-state/ignore #:min n #:max 3 #:ok? (between/c 1 366))]
     [(Day _ 'week/month n)
-     (num-parse ast loc state parse-state/ignore #:min n #:ok? (between/c 1 5))]
+     (num-parse ast loc state parse-state/ignore #:min n #:max 1 #:ok? (between/c 1 5))]
     [(Day _ 'jdn n)
      (define (update str fs jdn)
        (match-define (YMD y m d) (jdn->ymd jdn))

--- a/gregor-lib/gregor/private/pattern/ast/hour.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/hour.rkt
@@ -21,7 +21,7 @@
 
 (define (hour-parse ast state ci? loc)
   (define (parse n ok? update)
-    (num-parse ast loc state update #:min n #:ok? ok?))
+    (num-parse ast loc state update #:min n #:max 2 #:ok? ok?))
     
   (match ast
     [(Hour _ 'half n)

--- a/gregor-lib/gregor/private/pattern/ast/minute.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/minute.rkt
@@ -17,7 +17,7 @@
 (define (minute-parse ast state ci? loc)
   (match ast
     [(Minute _ n)
-     (num-parse ast loc state (parse-state/ minute) #:min n #:ok? (between/c 0 59))]))
+     (num-parse ast loc state (parse-state/ minute) #:min n #:max 2 #:ok? (between/c 0 59))]))
 
 (struct Minute Ast (size)
   #:transparent

--- a/gregor-lib/gregor/private/pattern/ast/month.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/month.rkt
@@ -21,7 +21,7 @@
 (define (month-parse ast state ci? loc)
   (match ast
     [(Month _ 'numeric n)
-     (num-parse ast loc state (parse-state/ month) #:min n #:ok? (between/c 1 12))]
+     (num-parse ast loc state (parse-state/ month) #:min n #:max 2 #:ok? (between/c 1 12))]
     [(Month _ kind size)
      (symnum-parse ast (month-trie loc ci? kind size) state (parse-state/ month))]))
 

--- a/gregor-lib/gregor/private/pattern/ast/quarter.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/quarter.rkt
@@ -21,7 +21,7 @@
 (define (quarter-parse ast state ci? loc)
   (match ast
     [(Quarter _ 'numeric n)
-     (num-parse ast loc state parse-state/ignore #:min n #:ok? (between/c 1 4))]
+     (num-parse ast loc state parse-state/ignore #:min n #:max 2 #:ok? (between/c 1 4))]
     [(Quarter _ kind size)
      (symnum-parse ast (quarter-trie loc ci? kind size) state parse-state/ignore)]))
 

--- a/gregor-lib/gregor/private/pattern/ast/second.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/second.rkt
@@ -23,7 +23,7 @@
 (define (second-parse ast state ci? loc)
   (match ast
     [(Second _ n)
-     (num-parse ast loc state (parse-state/ second) #:min n #:ok? (between/c 0 59))]))
+     (num-parse ast loc state (parse-state/ second) #:min n #:max 2 #:ok? (between/c 0 59))]))
 
 (define (second/frac-fmt ast t loc)
   (match ast

--- a/gregor-lib/gregor/private/pattern/ast/week.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/week.rkt
@@ -17,8 +17,8 @@
 
 (define (week-parse ast state ci? loc)
   (match ast
-    [(Week _ 'year n)  (num-parse ast loc state parse-state/ignore #:min n #:ok? (between/c 1 53))]
-    [(Week _ 'month n) (num-parse ast loc state parse-state/ignore #:min n #:ok? (between/c 1 6))]))
+    [(Week _ 'year n)  (num-parse ast loc state parse-state/ignore #:min n #:max 2 #:ok? (between/c 1 53))]
+    [(Week _ 'month n) (num-parse ast loc state parse-state/ignore #:min n #:max 1 #:ok? (between/c 1 6))]))
 
 (struct Week Ast (kind size)
   #:transparent

--- a/gregor-lib/gregor/private/pattern/ast/weekday.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/weekday.rkt
@@ -28,7 +28,7 @@
 (define (weekday/loc-parse ast state ci? loc)
   (match ast
     [(Weekday/Loc _ 'numeric n)
-     (num-parse ast loc state parse-state/ignore #:min n #:ok? (between/c 1 7))]
+     (num-parse ast loc state parse-state/ignore #:min n #:max n #:ok? (between/c 1 7))]
     [(Weekday/Loc _ kind size)
      (sym-parse ast (weekday-trie loc ci? kind size) state parse-state/ignore)]))
 


### PR DESCRIPTION
For example, when parsing a numeric month value, we shouldn't
consume more than two characters. Not all numeric fields can
be constrained like this, since some of them are specified to
allow a 1...n characters.

Fixes #35