### PR TITLE
Fix installation of gregor packages on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,9 @@ jobs:
           name: Install gregor
           command: |
             raco pkg install tzdata
-            raco pkg install --auto --link ./gregor
+            raco pkg install --auto --link ./gregor-lib
+            raco pkg install --auto --link ./gregor-test
+            raco pkg install --auto --link ./gregor-doc
 
       - run:
           name: Run gregor tests


### PR DESCRIPTION
I was previously linking the umbrella gregor package, but that
merely lists -lib, -doc, and -test as dependencies, which are
then fetched from the package server. So I wasn't running the
right code. 🤦‍♂ 