### PR TITLE
Allows year parser to consume exactly n digits in some patterns

### DIFF
--- a/gregor-lib/gregor/private/parse.rkt
+++ b/gregor-lib/gregor/private/parse.rkt
@@ -22,11 +22,16 @@
                         make-temporal)
   (define cldr-locale (locale->available-cldr-locale locale modern-locale?))
   (define initial-state (parse-state input (fresh-fields)))
-  (define xs (pattern->ast-list pattern))
+  (define ast-nodes (pattern->ast-list pattern))
+  (define next-ast-nodes
+    (if (null? ast-nodes)
+        null
+        (append (cdr ast-nodes) (list #f))))
 
   (match-define (parse-state remaining-input fields)
-    (for/fold ([s initial-state]) ([x (in-list xs)])
-      (ast-parse x s ci? cldr-locale)))
+    (for/fold ([s initial-state]) ([node (in-list ast-nodes)]
+                                   [next-node (in-list next-ast-nodes)])
+      (ast-parse node next-node s ci? cldr-locale)))
 
   (cond [(zero? (string-length remaining-input))
          (make-temporal fields)]

--- a/gregor-lib/gregor/private/pattern/ast.rkt
+++ b/gregor-lib/gregor/private/pattern/ast.rkt
@@ -12,7 +12,8 @@
 (define-generics ast
   (ast-fmt-contract ast)
   (ast-fmt ast t loc)
-  (ast-parse ast state ci? loc))
+  (ast-parse ast next-ast state ci? loc)
+  (ast-numeric? ast))
 
 (struct Ast (pat))
 
@@ -23,5 +24,3 @@
 (define (parse-error ast state)
   (raise-parse-error (Ast-pat ast)
                      (parse-state-input state)))
-
-  

--- a/gregor-lib/gregor/private/pattern/ast/day.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/day.rkt
@@ -18,7 +18,7 @@
     [(Day _ 'week/month n) (num-fmt loc (add1 (quotient (sub1 (->day t)) 7)) n)]
     [(Day _ 'jdn n)        (num-fmt loc (->jdn t) n)]))
 
-(define (day-parse ast state ci? loc)
+(define (day-parse ast next-ast state ci? loc)
   (match ast
     [(Day _ 'month n)
      (num-parse ast loc state (parse-state/ day) #:min n #:max 2 #:ok? (between/c 1 31))]
@@ -29,20 +29,23 @@
     [(Day _ 'jdn n)
      (define (update str fs jdn)
        (match-define (YMD y m d) (jdn->ymd jdn))
-       
+
        (parse-state
         str
         (struct-copy fields
                      (set-fields-year/ext fs y)
                      [month m]
                      [day d])))
-     
+
      (num-parse ast loc state update #:min n #:neg #t)]))
 
+(define (day-numeric? ast)
+  #t)
 
 (struct Day Ast (kind size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt day-fmt)
-   (define ast-parse day-parse)])
+   (define ast-parse day-parse)
+   (define ast-numeric? day-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/era.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/era.rkt
@@ -15,11 +15,15 @@
         "0"))
   (l10n-cal loc 'eras (Era-size ast) key))
 
-(define (era-parse ast state ci? loc)
+(define (era-parse ast next-ast state ci? loc)
   (symnum-parse ast (era-trie loc ci? (Era-size ast)) state (parse-state/ era)))
+
+(define (era-numeric? ast)
+  #f)
 
 (struct Era Ast (size)
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt era-fmt)
-   (define ast-parse era-parse)])
+   (define ast-parse era-parse)
+   (define ast-numeric? era-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/hour.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/hour.rkt
@@ -19,7 +19,7 @@
     [(Hour _ 'half/zero n) (num-fmt loc (remainder h 12) n)]
     [(Hour _ 'full/one n)  (num-fmt loc (mod1 h 24) n)]))
 
-(define (hour-parse ast state ci? loc)
+(define (hour-parse ast next-ast state ci? loc)
   (define (parse n ok? update)
     (num-parse ast loc state update #:min n #:max 2 #:ok? ok?))
     
@@ -41,10 +41,14 @@
             (λ (str fs h)
               (define res (if (= h 24) 0 h))
               (parse-state str (set-fields-hour/full fs res))))]))
+
+(define (hour-numeric? ast)
+  #t)
      
 (struct Hour Ast (kind size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt hour-fmt)
-   (define ast-parse hour-parse)])
+   (define ast-parse hour-parse)
+   (define ast-numeric? hour-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/literal.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/literal.rkt
@@ -11,7 +11,7 @@
   (match ast
     [(Literal _ txt) txt]))
 
-(define (literal-parse ast state ci? loc)
+(define (literal-parse ast next-ast state ci? loc)
   (match ast
     [(Literal _ txt)
      (define re (regexp (string-append "^" (regexp-quote txt))))
@@ -22,9 +22,13 @@
                       (parse-state-fields state))
          (parse-error ast state))]))
 
+(define (literal-numeric? ast)
+  #f)
+
 (struct Literal Ast (txt)
   #:transparent
   #:methods gen:ast
   [(define (ast-fmt-contract ast) any/c)
    (define ast-fmt literal-fmt)
-   (define ast-parse literal-parse)])
+   (define ast-parse literal-parse)
+   (define ast-numeric? literal-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/minute.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/minute.rkt
@@ -14,14 +14,18 @@
   (match ast
     [(Minute _ n) (num-fmt loc (->minutes t) n)]))
 
-(define (minute-parse ast state ci? loc)
+(define (minute-parse ast next-ast state ci? loc)
   (match ast
     [(Minute _ n)
      (num-parse ast loc state (parse-state/ minute) #:min n #:max 2 #:ok? (between/c 0 59))]))
+
+(define (minute-numeric? ast)
+  #t)
 
 (struct Minute Ast (size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt minute-fmt)
-   (define ast-parse minute-parse)])
+   (define ast-parse minute-parse)
+   (define ast-numeric? minute-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/month.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/month.rkt
@@ -18,16 +18,22 @@
     [(Month _ 'numeric n) (num-fmt loc m n)]
     [(Month _ kind size)  (l10n-cal loc 'months kind size m)]))
 
-(define (month-parse ast state ci? loc)
+(define (month-parse ast next-ast state ci? loc)
   (match ast
     [(Month _ 'numeric n)
      (num-parse ast loc state (parse-state/ month) #:min n #:max 2 #:ok? (between/c 1 12))]
     [(Month _ kind size)
      (symnum-parse ast (month-trie loc ci? kind size) state (parse-state/ month))]))
 
+(define (month-numeric? ast)
+  (match ast
+    [(Month _ 'numeric _) #t]
+    [_ #f]))
+
 (struct Month Ast (kind size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt month-fmt)
-   (define ast-parse month-parse)])
+   (define ast-parse month-parse)
+   (define ast-numeric? month-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/period.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/period.rkt
@@ -15,7 +15,7 @@
   (match ast
     [(Period _ size) (l10n-cal loc 'dayPeriods 'format size p)]))
 
-(define (period-parse ast state ci? loc)
+(define (period-parse ast next-ast state ci? loc)
   (match ast
     [(Period _ size)
      (sym-parse ast (period-trie loc ci? size) state
@@ -24,9 +24,13 @@
                     [(am pm) (parse-state str (struct-copy fields fs [period sym]))]
                     [else (parse-error ast state)])))]))
 
+(define (period-numeric? ast)
+  #f)
+
 (struct Period Ast (size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt period-fmt)
-   (define ast-parse period-parse)])
+   (define ast-parse period-parse)
+   (define ast-numeric? period-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/quarter.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/quarter.rkt
@@ -18,16 +18,22 @@
     [(Quarter _ 'numeric n) (num-fmt loc q n)]
     [(Quarter _ kind size)  (l10n-cal loc 'quarters kind size q)]))
 
-(define (quarter-parse ast state ci? loc)
+(define (quarter-parse ast next-ast state ci? loc)
   (match ast
     [(Quarter _ 'numeric n)
      (num-parse ast loc state parse-state/ignore #:min n #:max 2 #:ok? (between/c 1 4))]
     [(Quarter _ kind size)
      (symnum-parse ast (quarter-trie loc ci? kind size) state parse-state/ignore)]))
 
+(define (quarter-numeric? ast)
+  (match ast
+    [(Quarter _ 'numeric _) #t]
+    [_ #f]))
+
 (struct Quarter Ast (kind min)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt quarter-fmt)
-   (define ast-parse quarter-parse)])
+   (define ast-parse quarter-parse)
+   (define ast-numeric? quarter-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/second.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/second.rkt
@@ -20,7 +20,7 @@
   (match ast
     [(Second _ n) (num-fmt loc (->seconds t) n)]))
 
-(define (second-parse ast state ci? loc)
+(define (second-parse ast next-ast state ci? loc)
   (match ast
     [(Second _ n)
      (num-parse ast loc state (parse-state/ second) #:min n #:max 2 #:ok? (between/c 0 59))]))
@@ -34,7 +34,7 @@
       loc
       (~a nano-str #:align 'left #:width n #:pad-string "0"))]))
 
-(define (second/frac-parse ast state ci? loc)
+(define (second/frac-parse ast next-ast state ci? loc)
   (match ast
     [(SecondFraction _ n)
      (define input (parse-state-input state))
@@ -59,7 +59,7 @@
      
      (num-fmt loc ms n)]))
 
-(define (millisecond-parse ast state ci? loc)
+(define (millisecond-parse ast next-ast state ci? loc)
   (match ast
     [(Millisecond _ n)
      (define (update str fs ms)
@@ -78,23 +78,29 @@
      
      (num-parse ast loc state update #:min n #:ok? (between/c 0 (sub1 MILLI/DAY)))]))
 
+(define (second-numeric? ast)
+  #t)
+
 (struct Second Ast (size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt second-fmt)
-   (define ast-parse second-parse)])
+   (define ast-parse second-parse)
+   (define ast-numeric? second-numeric?)])
 
 (struct SecondFraction Ast (size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt second/frac-fmt)
-   (define ast-parse second/frac-parse)])
+   (define ast-parse second/frac-parse)
+   (define ast-numeric? second-numeric?)])
 
 (struct Millisecond Ast (size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt millisecond-fmt)
-   (define ast-parse millisecond-parse)])
+   (define ast-parse millisecond-parse)
+   (define ast-numeric? second-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/separator.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/separator.rkt
@@ -11,7 +11,7 @@
 (define (time-separator-fmt ast t loc)
   (time-separator loc))
 
-(define (time-separator-parse ast state ci? loc)
+(define (time-separator-parse ast next-ast state ci? loc)
   (define sep (time-separator loc))
   (define re (regexp (string-append "^" (regexp-quote sep))))
   (define input (parse-state-input state))
@@ -21,9 +21,13 @@
                    (parse-state-fields state))
       (parse-error ast state)))
 
+(define (separator-numeric? ast)
+  #f)
+
 (struct TimeSeparator Ast ()
   #:transparent
   #:methods gen:ast
   [(define (ast-fmt-contract ast) any/c)
    (define ast-fmt time-separator-fmt)
-   (define ast-parse time-separator-parse)])
+   (define ast-parse time-separator-parse)
+   (define ast-numeric? separator-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/week.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/week.rkt
@@ -15,14 +15,18 @@
     [(Week _ 'year n)  (num-fmt loc (l10n-week-of-year loc t) n)]
     [(Week _ 'month n) (num-fmt loc (l10n-week-of-month loc t) n)]))
 
-(define (week-parse ast state ci? loc)
+(define (week-parse ast next-ast state ci? loc)
   (match ast
     [(Week _ 'year n)  (num-parse ast loc state parse-state/ignore #:min n #:max 2 #:ok? (between/c 1 53))]
     [(Week _ 'month n) (num-parse ast loc state parse-state/ignore #:min n #:max 1 #:ok? (between/c 1 6))]))
+
+(define (week-numeric? ast)
+  #t)
 
 (struct Week Ast (kind size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt week-fmt)
-   (define ast-parse week-parse)])
+   (define ast-parse week-parse)
+   (define ast-numeric? week-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/weekday.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/weekday.rkt
@@ -25,28 +25,40 @@
   (match ast
     [(Weekday/Std _ kind size) (l10n-cal loc 'days kind size (->dow t))]))
 
-(define (weekday/loc-parse ast state ci? loc)
+(define (weekday/loc-parse ast next-ast state ci? loc)
   (match ast
     [(Weekday/Loc _ 'numeric n)
      (num-parse ast loc state parse-state/ignore #:min n #:max n #:ok? (between/c 1 7))]
     [(Weekday/Loc _ kind size)
      (sym-parse ast (weekday-trie loc ci? kind size) state parse-state/ignore)]))
 
-(define (weekday/std-parse ast state ci? loc)
+(define (weekday/std-parse ast next-ast state ci? loc)
   (match ast
     [(Weekday/Std _ kind size)
      (sym-parse ast (weekday-trie loc ci? kind size) state parse-state/ignore)]))
+
+(define (weekday/loc-numeric? ast)
+  (match ast
+    [(Weekday/Loc _ 'numeric _) #t]
+    [_ #f]))
+
+(define (weekday/std-numeric? ast)
+  (match ast
+    [(Weekday/Std _ 'numeric _) #t]
+    [_ #f]))
 
 (struct Weekday/Loc Ast (kind size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt weekday/loc-fmt)
-   (define ast-parse weekday/loc-parse)])
+   (define ast-parse weekday/loc-parse)
+   (define ast-numeric? weekday/loc-numeric?)])
 
 (struct Weekday/Std Ast (kind size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt weekday/std-fmt)
-   (define ast-parse weekday/std-parse)])
+   (define ast-parse weekday/std-parse)
+   (define ast-numeric? weekday/std-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/zone.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/zone.rkt
@@ -36,7 +36,7 @@
     [(Zone _ 'gmt _)              moment-provider?]
     [_                            tzid-provider?]))
 
-(define (zone-parse ast state ci? loc)
+(define (zone-parse ast next-ast state ci? loc)
   (match ast
     [(Zone _ 'iso/basic pat)      (zone/iso-parse ast state pat #f "")]
     [(Zone _ 'iso/basic/z pat)    (zone/iso-parse ast state pat #t "")]
@@ -45,10 +45,13 @@
     [(Zone _ 'id 'short)          (zone-short-id-parse ast state ci?)]
     [(Zone _ 'id 'long)           (zone-long-id-parse ast state ci?)]))
 
+(define (zone-numeric? ast)
+  #f)
+
 (struct Zone Ast (kind size)
   #:transparent
   #:methods gen:ast
   [(define ast-fmt-contract zone-fmt-contract)
    (define ast-fmt zone-fmt)
-   (define ast-parse zone-parse)])
-
+   (define ast-parse zone-parse)
+   (define ast-numeric? zone-numeric?)])

--- a/gregor-test/gregor/tests/parse.rkt
+++ b/gregor-test/gregor/tests/parse.rkt
@@ -58,7 +58,8 @@
          (parameterize ([current-two-digit-year-resolver (λ (y) (+ y 1700))])
            (check-equal? (->year (parse-date "56" "yy")) 1756))
 
-         (check-equal? (->year (parse-date "02000" "yyyyy")) 2000))
+         (check-equal? (->year (parse-date "02000" "yyyyy")) 2000)
+         (check-equal? (parse-date "20191115" "yyyyMMdd") (date 2019 11 15)))
 
        (test-suite "[Y]"
          ;; Week-based year does not contribute to parse data.
@@ -70,13 +71,15 @@
 
          (check-equal? (->year (parse-date "2005-01-01 / ISO 04" "uuuu-MM-dd / 'ISO' YY")) 2005)
          (check-equal? (->year (parse-date "532020" "wwy")) 2020)
+         (check-equal? (->year (parse-date "1900 202020" "u YYYYww")) 1900)
          (check-equal? (->year (parse-date "52020" "Wy")) 2020))
 
        (test-suite "[u]"
          (check-equal? (->year (parse-date "2000" "u")) 2000)
          (check-equal? (->year (parse-date "9000" "uu")) 9000) ; no special case
          (check-equal? (->year (parse-date "02000" "uuuuu")) 2000)
-         (check-equal? (->year (parse-date "-2000" "u")) -2000))
+         (check-equal? (->year (parse-date "-2000" "u")) -2000)
+         (check-equal? (parse-date "20191115" "uuuuMMdd") (date 2019 11 15)))
 
        (test-suite "[U]"
          ;; like y without special case for UU


### PR DESCRIPTION
As pointed out in #41, a date format like "20191123" cannot be
parsed using a strict interpretation of CLDR patterns, since
there is no way to specify that a year should occupy exactly
n (= 4) digits. CLDR itself advocates "lenient parsing" as a
general approach, which I think is a terrible idea (not that
lenient parsing is per se a bad idea but that it's an awful
default).

This PR allows formats like the above to be parsed by treating
year pattern specially. If the pattern following a year pattern
is numeric, then we will treat the year pattern as specifying
an exact number of digits to parse, instead of a minimum. This
is a trick that the Joda-Time library uses, and it seems like
a reasonable and simple approach.

Note that non-year patterns do not work this way, since they
typically already have sensible behavior. A pattern of "M,"
for example, matches at least one digit as a month -- but it
also has a built-in maximum of two digits. There seems no
point in saying that "M" should match exactly one digit when
the following pattern is numeric, because no sensible date
format would insist on matching exactly one digit for a month.