### PR TITLE
~t format compile

### DIFF
--- a/gregor-lib/gregor/private/format.rkt
+++ b/gregor-lib/gregor/private/format.rkt
@@ -2,31 +2,42 @@
 
 (require racket/contract/base
          racket/set
+         racket/string
          cldr/core
          cldr/likely-subtags
+         memoize
          "generics.rkt"
          "pattern/ast.rkt"
          "pattern/lexer.rkt")
 
+(define/memo* (compile-pattern-format pattern locale)
+  (define ast (pattern->ast-list pattern))
+  (define contract
+    (for*/fold ([cs (set)]
+                #:result (apply and/c (set->list cs)))
+               ([part (in-list ast)]
+                [c (in-value (ast-fmt-contract part))]
+                #:unless (equal? c any/c))
+      (set-add cs c)))
+  (define loc (locale->available-cldr-locale locale modern-locale?))
+  (define fmts
+    (for/list ([part (in-list ast)])
+      (ast-fmt-compile part loc)))
+
+  (lambda (t)
+    (cond [(not (contract t))
+           (raise-argument-error '~t
+                                 (format "~s" (contract-name contract))
+                                 0
+                                 t
+                                 pattern)]
+          [else
+            (string-append*
+              (for/list ([fmt (in-list fmts)])
+                (fmt t)))])))
+
 (define (~t t pattern #:locale [locale (current-locale)])
-  (define xs (pattern->ast-list pattern))
-  (define required
-    (for*/set ([x (in-list xs)]
-               [c (in-value (ast-fmt-contract x))]
-               #:unless (equal? c any/c))
-      c))
-  (define omnibus/c (apply and/c (set->list required)))
-  
-  (cond [(not (omnibus/c t))
-         (raise-argument-error '~t
-                               (format "~s" (contract-name omnibus/c))
-                               0
-                               t
-                               pattern)]
-        [else
-         (define cldr-locale (locale->available-cldr-locale locale modern-locale?))
-         (define fragments (for/list ([x (in-list xs)]) (ast-fmt x t cldr-locale)))
-         (apply string-append fragments)]))
+  ((compile-pattern-format pattern locale) t))
 
 (provide/contract
  [~t (->i ([t (or/c date-provider? time-provider?)]

--- a/gregor-lib/gregor/private/pattern/ast.rkt
+++ b/gregor-lib/gregor/private/pattern/ast.rkt
@@ -12,6 +12,7 @@
 (define-generics ast
   (ast-fmt-contract ast)
   (ast-fmt ast t loc)
+  (ast-fmt-compile ast loc)
   (ast-parse ast next-ast state ci? loc)
   (ast-numeric? ast))
 

--- a/gregor-lib/gregor/private/pattern/ast/day.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/day.rkt
@@ -18,6 +18,18 @@
     [(Day _ 'week/month n) (num-fmt loc (add1 (quotient (sub1 (->day t)) 7)) n)]
     [(Day _ 'jdn n)        (num-fmt loc (->jdn t) n)]))
 
+(define (day-fmt-compile ast loc)
+  (match-define (Day _ type width) ast)
+  (define num-fmt (num-fmt-compile loc width))
+  (define day-value
+    (match type
+      ['month ->day]
+      ['year  ->yday]
+      ['jdn   ->jdn]
+      ['week/month
+        (lambda (t) (add1 (quotient (sub1 (->day t)) 7)))]))
+  (compose1 num-fmt day-value))
+
 (define (day-parse ast next-ast state ci? loc)
   (match ast
     [(Day _ 'month n)
@@ -47,5 +59,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt day-fmt)
+   (define ast-fmt-compile day-fmt-compile)
    (define ast-parse day-parse)
    (define ast-numeric? day-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/era.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/era.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require "../../generics.rkt"
+(require cldr/core
+         "../../generics.rkt"
          "../ast.rkt"
          "../parse-state.rkt"
          "../l10n/named-trie.rkt"
@@ -15,6 +16,14 @@
         "0"))
   (l10n-cal loc 'eras (Era-size ast) key))
 
+(define (era-fmt-compile ast loc)
+  (define tbl
+    (l10n-cal loc 'eras (Era-size ast)))
+  (lambda (t)
+    (define key
+      (if (positive? (->year t)) "1" "0"))
+    (cldr-ref tbl key)))
+
 (define (era-parse ast next-ast state ci? loc)
   (symnum-parse ast (era-trie loc ci? (Era-size ast)) state (parse-state/ era)))
 
@@ -25,5 +34,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt era-fmt)
+   (define ast-fmt-compile era-fmt-compile)
    (define ast-parse era-parse)
    (define ast-numeric? era-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/hour.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/hour.rkt
@@ -19,6 +19,16 @@
     [(Hour _ 'half/zero n) (num-fmt loc (remainder h 12) n)]
     [(Hour _ 'full/one n)  (num-fmt loc (mod1 h 24) n)]))
 
+(define (hour-fmt-compile ast loc)
+  (match-define (Hour _ kind n) ast)
+  (compose1 (num-fmt-compile loc n)
+            (match kind
+              ['half      (lambda (h) (mod1 h 12))]
+              ['full      values]
+              ['half/zero (lambda (h) (remainder h 12))]
+              ['full/one  (lambda (h) (mod1 h 24))])
+            ->hours))
+
 (define (hour-parse ast next-ast state ci? loc)
   (define (parse n ok? update)
     (num-parse ast loc state update #:min n #:max 2 #:ok? ok?))
@@ -50,5 +60,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt hour-fmt)
+   (define ast-fmt-compile hour-fmt-compile)
    (define ast-parse hour-parse)
    (define ast-numeric? hour-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/literal.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/literal.rkt
@@ -11,6 +11,10 @@
   (match ast
     [(Literal _ txt) txt]))
 
+(define (literal-fmt-compile ast loc)
+  (match-define (Literal _ txt) ast)
+  (lambda (t) txt))
+
 (define (literal-parse ast next-ast state ci? loc)
   (match ast
     [(Literal _ txt)
@@ -30,5 +34,6 @@
   #:methods gen:ast
   [(define (ast-fmt-contract ast) any/c)
    (define ast-fmt literal-fmt)
+   (define ast-fmt-compile literal-fmt-compile)
    (define ast-parse literal-parse)
    (define ast-numeric? literal-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/minute.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/minute.rkt
@@ -14,6 +14,11 @@
   (match ast
     [(Minute _ n) (num-fmt loc (->minutes t) n)]))
 
+(define (minute-fmt-compile ast loc)
+  (match-define (Minute _ n) ast)
+  (define num-fmt (num-fmt-compile loc n))
+  (compose1 num-fmt ->minutes))
+
 (define (minute-parse ast next-ast state ci? loc)
   (match ast
     [(Minute _ n)
@@ -27,5 +32,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt minute-fmt)
+   (define ast-fmt-compile minute-fmt-compile)
    (define ast-parse minute-parse)
    (define ast-numeric? minute-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/month.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/month.rkt
@@ -2,6 +2,7 @@
 
 (require racket/contract/base
          racket/match
+         cldr/core
          "../../generics.rkt"
          "../ast.rkt"
          "../parse-state.rkt"
@@ -17,6 +18,16 @@
   (match ast
     [(Month _ 'numeric n) (num-fmt loc m n)]
     [(Month _ kind size)  (l10n-cal loc 'months kind size m)]))
+
+(define (month-fmt-compile ast loc)
+  (define fmt
+    (match ast
+      [(Month _ 'numeric n) (num-fmt-compile loc n)]
+      [(Month _ kind size)
+       (let ([months (l10n-cal loc 'months kind size)])
+         (lambda (m)
+           (cldr-ref months m)))]))
+  (compose1 fmt ->month))
 
 (define (month-parse ast next-ast state ci? loc)
   (match ast
@@ -35,5 +46,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt month-fmt)
+   (define ast-fmt-compile month-fmt-compile)
    (define ast-parse month-parse)
    (define ast-numeric? month-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/period.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/period.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require racket/match
+         cldr/core
          "../../generics.rkt"
          "../ast.rkt"
          "../parse-state.rkt"
@@ -14,6 +15,13 @@
   
   (match ast
     [(Period _ size) (l10n-cal loc 'dayPeriods 'format size p)]))
+
+(define (period-fmt-compile ast loc)
+  (match-define (Period _ size) ast)
+  (define periods
+    (l10n-cal loc 'dayPeriods 'format size))
+  (lambda (t)
+    (cldr-ref periods (if (< (->hours t) 12) 'am 'pm))))
 
 (define (period-parse ast next-ast state ci? loc)
   (match ast
@@ -32,5 +40,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt period-fmt)
+   (define ast-fmt-compile period-fmt-compile)
    (define ast-parse period-parse)
    (define ast-numeric? period-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/quarter.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/quarter.rkt
@@ -2,6 +2,7 @@
 
 (require racket/contract/base
          racket/match
+         cldr/core
          "../../generics.rkt"
          "../ast.rkt"
          "../parse-state.rkt"
@@ -17,6 +18,19 @@
   (match ast
     [(Quarter _ 'numeric n) (num-fmt loc q n)]
     [(Quarter _ kind size)  (l10n-cal loc 'quarters kind size q)]))
+
+(define (quarter-fmt-compile ast loc)
+  (define fmt
+    (match ast
+      [(Quarter _ 'numeric n)
+       (num-fmt-compile loc n)]
+      [(Quarter _ kind size)
+       (define tbl
+         (l10n-cal loc 'quarters kind size))
+       (lambda (q)
+         (cldr-ref tbl q))]))
+  (lambda (t)
+    (fmt (->quarter t))))
 
 (define (quarter-parse ast next-ast state ci? loc)
   (match ast
@@ -35,5 +49,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt quarter-fmt)
+   (define ast-fmt-compile quarter-fmt-compile)
    (define ast-parse quarter-parse)
    (define ast-numeric? quarter-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/second.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/second.rkt
@@ -20,6 +20,10 @@
   (match ast
     [(Second _ n) (num-fmt loc (->seconds t) n)]))
 
+(define (second-fmt-compile ast loc)
+  (match-define (Second _ n) ast)
+  (compose1 (num-fmt-compile loc n) ->seconds))
+
 (define (second-parse ast next-ast state ci? loc)
   (match ast
     [(Second _ n)
@@ -86,6 +90,7 @@
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt second-fmt)
+   (define ast-fmt-compile second-fmt-compile)
    (define ast-parse second-parse)
    (define ast-numeric? second-numeric?)])
 

--- a/gregor-lib/gregor/private/pattern/ast/second.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/second.rkt
@@ -38,6 +38,16 @@
       loc
       (~a nano-str #:align 'left #:width n #:pad-string "0"))]))
 
+(define (second/frac-fmt-compile ast loc)
+  (define fmt (num-string-translate-compile loc))
+  (match ast
+    [(SecondFraction _ n)
+     (lambda (t)
+       (define nano-str
+         (~a (->nanoseconds t) #:align 'right #:width 9 #:pad-string "0"))
+       (fmt
+         (~a nano-str #:align 'left #:width n #:pad-string "0")))]))
+
 (define (second/frac-parse ast next-ast state ci? loc)
   (match ast
     [(SecondFraction _ n)
@@ -99,6 +109,7 @@
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt second/frac-fmt)
+   (define ast-fmt-compile second/frac-fmt-compile)
    (define ast-parse second/frac-parse)
    (define ast-numeric? second-numeric?)])
 

--- a/gregor-lib/gregor/private/pattern/ast/second.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/second.rkt
@@ -73,6 +73,13 @@
      
      (num-fmt loc ms n)]))
 
+(define (millisecond-fmt-compile ast loc)
+  (define fmt
+    (match ast
+      [(Millisecond _ n) (num-fmt-compile loc n)]))
+  (lambda (t)
+    (fmt (quotient (time->ns (->time t)) NS/MILLI))))
+
 (define (millisecond-parse ast next-ast state ci? loc)
   (match ast
     [(Millisecond _ n)
@@ -118,5 +125,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract time-provider-contract)
    (define ast-fmt millisecond-fmt)
+   (define ast-fmt-compile millisecond-fmt-compile)
    (define ast-parse millisecond-parse)
    (define ast-numeric? second-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/separator.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/separator.rkt
@@ -11,6 +11,10 @@
 (define (time-separator-fmt ast t loc)
   (time-separator loc))
 
+(define (time-separator-fmt-compile ast loc)
+  (define v (time-separator loc))
+  (lambda (t) v))
+
 (define (time-separator-parse ast next-ast state ci? loc)
   (define sep (time-separator loc))
   (define re (regexp (string-append "^" (regexp-quote sep))))
@@ -29,5 +33,6 @@
   #:methods gen:ast
   [(define (ast-fmt-contract ast) any/c)
    (define ast-fmt time-separator-fmt)
+   (define ast-fmt-compile time-separator-fmt-compile)
    (define ast-parse time-separator-parse)
    (define ast-numeric? separator-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/week.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/week.rkt
@@ -15,6 +15,18 @@
     [(Week _ 'year n)  (num-fmt loc (l10n-week-of-year loc t) n)]
     [(Week _ 'month n) (num-fmt loc (l10n-week-of-month loc t) n)]))
 
+(define (week-fmt-compile ast loc)
+  (match ast
+    [(Week _ 'year n)
+     (define fmt (num-fmt-compile loc n))
+     (lambda (t)
+       (fmt (l10n-week-of-year loc t)))]
+    [(Week _ 'month n)
+     (define fmt
+       (num-fmt-compile loc n))
+     (lambda (t)
+       (fmt (l10n-week-of-month loc t)))]))
+
 (define (week-parse ast next-ast state ci? loc)
   (match ast
     [(Week _ 'year n)  (num-parse ast loc state parse-state/ignore #:min n #:max 2 #:ok? (between/c 1 53))]
@@ -28,5 +40,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt week-fmt)
+   (define ast-fmt-compile week-fmt-compile)
    (define ast-parse week-parse)
    (define ast-numeric? week-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/weekday.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/weekday.rkt
@@ -22,6 +22,17 @@
     [(Weekday/Loc _ 'numeric n) (num-fmt loc (l10n-cwday loc t) n)]
     [(Weekday/Loc _ kind size)  (l10n-cal loc 'days kind size (->dow t))]))
 
+(define (weekday/loc-fmt-compile ast loc)
+  (match ast
+    [(Weekday/Loc _ 'numeric n)
+     (define fmt (num-fmt-compile loc n))
+     (lambda (t)
+       (fmt (l10n-cwday loc t)))]
+    [(Weekday/Loc _ kind size)
+     (define days (l10n-cal loc 'days kind size))
+     (lambda (t)
+       (cldr-ref days (->dow t)))]))
+
 (define (weekday/std-fmt ast t loc)
   (match ast
     [(Weekday/Std _ kind size) (l10n-cal loc 'days kind size (->dow t))]))
@@ -61,6 +72,7 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt weekday/loc-fmt)
+   (define ast-fmt-compile weekday/loc-fmt-compile)
    (define ast-parse weekday/loc-parse)
    (define ast-numeric? weekday/loc-numeric?)])
 

--- a/gregor-lib/gregor/private/pattern/ast/weekday.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/weekday.rkt
@@ -2,6 +2,7 @@
 
 (require racket/contract/base
          racket/match
+         cldr/core
          "../../generics.rkt"
          "../ast.rkt"
          "../parse-state.rkt"
@@ -24,6 +25,14 @@
 (define (weekday/std-fmt ast t loc)
   (match ast
     [(Weekday/Std _ kind size) (l10n-cal loc 'days kind size (->dow t))]))
+
+(define (weekday/std-fmt-compile ast loc)
+  (match-define
+    (Weekday/Std _ kind size) ast)
+  (define days
+    (l10n-cal loc 'days kind size))
+  (lambda (t)
+    (cldr-ref days (->dow t))))
 
 (define (weekday/loc-parse ast next-ast state ci? loc)
   (match ast
@@ -60,5 +69,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt weekday/std-fmt)
+   (define ast-fmt-compile weekday/std-fmt-compile)
    (define ast-parse weekday/std-parse)
    (define ast-numeric? weekday/std-numeric?)])

--- a/gregor-lib/gregor/private/pattern/ast/year.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/year.rkt
@@ -26,6 +26,27 @@
     [(Year _ 'cyclic _)   (num-fmt loc (era Y) 1)]
     [(Year _ 'related n)  (num-fmt loc Y n)]))
 
+(define (year-fmt-compile ast loc)
+  (define (short y) (remainder y 100))
+  (define (era y) (if (positive? y) y (abs (sub1 y))))
+  (define (wyear t) (l10n-week-based-year loc t))
+  (define num-fmt2 (num-fmt-compile loc 2))
+  (match ast
+    [(Year _ 'normal 2)
+     (compose1 num-fmt2 short era ->year)]
+    [(Year _ 'normal w)
+     (compose1 (num-fmt-compile loc w) era ->year)]
+    [(Year _ 'week 2)
+     (compose1 num-fmt2 short era wyear)]
+    [(Year _ 'week w)
+     (compose1 (num-fmt-compile loc w) era wyear)]
+    [(Year _ 'ext w)
+     (compose1 (num-fmt-compile loc w) ->year)]
+    [(Year _ 'cyclic _)
+     (compose1 (num-fmt-compile loc 1) era ->year)]
+    [(Year _ 'related w)
+     (compose1 (num-fmt-compile loc w) ->year)]))
+
 (define (year-parse ast next-ast state ci? loc)
   (define (min->max n)
     (if (and next-ast (ast-numeric? next-ast))
@@ -64,6 +85,7 @@
   #:methods gen:ast
   [(define ast-fmt-contract date-provider-contract)
    (define ast-fmt year-fmt)
+   (define ast-fmt-compile year-fmt-compile)
    (define ast-parse year-parse)
    (define ast-numeric? year-numeric?)])
 

--- a/gregor-lib/gregor/private/pattern/ast/zone.rkt
+++ b/gregor-lib/gregor/private/pattern/ast/zone.rkt
@@ -27,6 +27,10 @@
     [(Zone _ 'city _)             (zone/city-fmt loc t)]
     [(Zone _ 'generic/loc _)      (zone/generic-loc-fmt loc t)]))
 
+(define (zone-fmt-compile ast loc)
+  (lambda (t)
+    (zone-fmt ast t loc)))
+
 (define (zone-fmt-contract ast)
   (match ast
     [(Zone _ 'iso/basic _)        moment-provider?]
@@ -53,5 +57,6 @@
   #:methods gen:ast
   [(define ast-fmt-contract zone-fmt-contract)
    (define ast-fmt zone-fmt)
+   (define ast-fmt-compile zone-fmt-compile)
    (define ast-parse zone-parse)
    (define ast-numeric? zone-numeric?)])

--- a/gregor-lib/gregor/private/pattern/l10n/numbers.rkt
+++ b/gregor-lib/gregor/private/pattern/l10n/numbers.rkt
@@ -9,8 +9,10 @@
          "../parse-state.rkt")
 
 (provide num-fmt
+         num-fmt-compile
          num-parse
          num-string-translate
+         num-string-translate-compile
          num-string-untranslate
          num-re
          number-system-symbols
@@ -20,6 +22,13 @@
   (num-string-translate
    loc
    (~a n #:align 'right #:min-width min-width #:pad-string "0")))
+
+(define (num-fmt-compile loc min-width)
+  (define locale-digits (numeral-string loc))
+  (lambda (n)
+    (define str
+      (~a n #:align 'right #:min-width min-width #:pad-string "0"))
+    (substitute str locale-digits ZERO)))
 
 (define (num-parse ast loc state update #:min min #:max [max #f] #:neg [neg #f] #:ok? [ok? (λ (x) #t)])
   (define input (parse-state-input state))
@@ -41,6 +50,10 @@
 
 (define (num-string-translate loc str)
   (substitute str (numeral-string loc) ZERO))
+
+(define (num-string-translate-compile loc)
+  (lambda (str)
+    (substitute str (numeral-string loc) ZERO)))
 
 (define (num-string-untranslate loc str)
   (substitute str


### PR DESCRIPTION
These patches improve the performance of the `~t` time object formatter.  Basically instead of recomputing a string conversion function for the format string each time `~t` is used we memoize the function based on the format string and locale.  The 'compiled' functions also close over the static results of some CLDR lookups instead of performing them every time.

Some benchmark comparisons at https://gist.github.com/samdphillips/395fa1707ba12850e17ed9625e812990
