### PR TITLE
Depend on memoize-lib instead of memoize

### DIFF
--- a/gregor-lib/info.rkt
+++ b/gregor-lib/info.rkt
@@ -4,7 +4,7 @@
 (define collection 'multi)
 (define deps '("base"
                "data-lib"
-               "memoize"
+               "memoize-lib"
                "parser-tools-lib"
                "tzinfo"
                "cldr-core"


### PR DESCRIPTION
Memoize recently split, so gregor-lib can avoiding pulling in memoize-doc (and Scribble, and docs, etc) as a dependency. 