### PR TITLE
serialization: provide deserialize-info from toplevel modules

### DIFF
--- a/gregor-lib/gregor/private/date.rkt
+++ b/gregor-lib/gregor/private/date.rkt
@@ -1,10 +1,11 @@
 #lang racket/base
 
-(require racket/contract/base
+(require data/order
+         racket/contract/base
          racket/format
          racket/match
+         racket/runtime-path
          racket/serialize
-         data/order
          "core/compare.rkt"
          "core/structs.rkt"
          "core/ymd.rkt")
@@ -87,8 +88,8 @@
    jdn->date
    (λ () (error "Date cannot have cycles"))))
 
-;; See racket/racket#4967
-(provide deserialize-info:Date)
+;; See 97jaz/gregor#59
+(runtime-require (submod "." deserialize-info))
 
 (module+ deserialize-info
   (provide deserialize-info:Date))

--- a/gregor-lib/gregor/private/date.rkt
+++ b/gregor-lib/gregor/private/date.rkt
@@ -87,6 +87,9 @@
    jdn->date
    (λ () (error "Date cannot have cycles"))))
 
+;; See racket/racket#4967
+(provide deserialize-info:Date)
+
 (module+ deserialize-info
   (provide deserialize-info:Date))
 

--- a/gregor-lib/gregor/private/datetime.rkt
+++ b/gregor-lib/gregor/private/datetime.rkt
@@ -74,6 +74,9 @@
    jd->datetime
    (λ () (error "DateTime cannot have cycles"))))
 
+;; See racket/racket#4967
+(provide deserialize-info:DateTime)
+
 (module+ deserialize-info
   (provide deserialize-info:DateTime))
 

--- a/gregor-lib/gregor/private/datetime.rkt
+++ b/gregor-lib/gregor/private/datetime.rkt
@@ -1,13 +1,14 @@
 #lang racket/base
 
-(require racket/contract/base
+(require data/order
+         racket/contract/base
          racket/match
          racket/math
+         racket/runtime-path
          racket/serialize
-         data/order
          "core/compare.rkt"
-         "core/ymd.rkt"
          "core/hmsn.rkt"
+         "core/ymd.rkt"
          "date.rkt"
          "time.rkt")
 
@@ -74,8 +75,8 @@
    jd->datetime
    (λ () (error "DateTime cannot have cycles"))))
 
-;; See racket/racket#4967
-(provide deserialize-info:DateTime)
+;; See 97jaz/gregor#59
+(runtime-require (submod "." deserialize-info))
 
 (module+ deserialize-info
   (provide deserialize-info:DateTime))

--- a/gregor-lib/gregor/private/moment-base.rkt
+++ b/gregor-lib/gregor/private/moment-base.rkt
@@ -2,9 +2,10 @@
 
 (require racket/format
          racket/match
+         racket/runtime-path
          racket/serialize
-         "datetime.rkt"
-         "core/compare.rkt")
+         "core/compare.rkt"
+         "datetime.rkt")
 
 (provide (all-defined-out))
 
@@ -72,8 +73,8 @@
    Moment
    (λ () (error "Moment cannot have cycles"))))
 
-;; See racket/racket#4967
-(provide deserialize-info:Moment)
+;; See 97jaz/gregor#59
+(runtime-require (submod "." deserialize-info))
 
 (module+ deserialize-info
   (provide deserialize-info:Moment))

--- a/gregor-lib/gregor/private/moment-base.rkt
+++ b/gregor-lib/gregor/private/moment-base.rkt
@@ -72,6 +72,9 @@
    Moment
    (λ () (error "Moment cannot have cycles"))))
 
+;; See racket/racket#4967
+(provide deserialize-info:Moment)
+
 (module+ deserialize-info
   (provide deserialize-info:Moment))
 

--- a/gregor-lib/gregor/private/time.rkt
+++ b/gregor-lib/gregor/private/time.rkt
@@ -65,6 +65,9 @@
    day-ns->time
    (λ () (error "Time cannot have cycles"))))
 
+;; See racket/racket#4967
+(provide deserialize-info:Time)
+
 (module+ deserialize-info
   (provide deserialize-info:Time))
 

--- a/gregor-lib/gregor/private/time.rkt
+++ b/gregor-lib/gregor/private/time.rkt
@@ -1,13 +1,14 @@
 #lang racket/base
 
-(require racket/contract/base
+(require data/order
+         racket/contract/base
          racket/format
          racket/match
+         racket/runtime-path
          racket/serialize
-         data/order
          "core/compare.rkt"
-         "core/structs.rkt"
-         "core/hmsn.rkt")
+         "core/hmsn.rkt"
+         "core/structs.rkt")
 
 (define (time-equal-proc x y _)
   (= (Time-ns x) (Time-ns y)))
@@ -65,8 +66,8 @@
    day-ns->time
    (λ () (error "Time cannot have cycles"))))
 
-;; See racket/racket#4967
-(provide deserialize-info:Time)
+;; See 97jaz/gregor#59
+(runtime-require (submod "." deserialize-info))
 
 (module+ deserialize-info
   (provide deserialize-info:Time))


### PR DESCRIPTION
This change makes it so that the following program runs successfully after being converted to an executable using `raco exe`:

    #lang racket/base

    (require gregor
             racket/serialize)

    (deserialize (serialize (current-time)))
    (deserialize (serialize (today)))
    (deserialize (serialize (now/moment)))

As it stands, the deserialization process fails to look up the `deserialization-info` submodules in an exe. On failure, that process then has a fallback that looks at the toplevel module where the struct is declared to get the info. So, this change fixes the issue by providing the info directly from the toplevel modules in addition to the `deserialization-info` submodules.

See racket/racket#4967 for more details.